### PR TITLE
Zeplin Fixes: Fixes for a Zeplin issue that skipped screens

### DIFF
--- a/scripts/zeplin-flowdock-integration.ts
+++ b/scripts/zeplin-flowdock-integration.ts
@@ -231,9 +231,12 @@ function checkForNotifications(logger, brain) {
 module.exports = function(robot) {
     let SECONDS = 1000,
         MINUTES = 60 * SECONDS,
-        MINUTE = MINUTES;
+        MINUTE = MINUTES,
 
-    checkForNotifications(robot.logger, robot.brain)();
-    setInterval(checkForNotifications(robot.logger, robot.brain), 1 * MINUTE);
+        notificationChecker = checkForNotifications(robot.logger, robot.brain);
+
+    notificationChecker().then(_ => {
+        setInterval(notificationChecker, 1 * MINUTE);
+    });
   }
   


### PR DESCRIPTION
Observation yields fixes! We were using `return` instead of `continue` in
a loop when we ran into a screen that we couldn't look up correctly. This
happened for screens that we'd been notified of but that no longer existed.
Now we correctly `continue`, so other screens are attempted.

Also some other tweaks, mostly to improve logging further.