### PR TITLE
Let dad go anywhere, but call him less often

### DIFF
--- a/scripts/access-limit-room.js
+++ b/scripts/access-limit-room.js
@@ -18,7 +18,6 @@ var ALLOWED_ROOMS, RESTRICTED_COMMANDS;
 
 RESTRICTED_COMMANDS = [
   'badgers',
-  'dad-jokes',
   'pod-bay-doors',
   'schedule'
 ]; // String that matches the listener ID

--- a/scripts/sandbox.js
+++ b/scripts/sandbox.js
@@ -24,7 +24,7 @@ const
     };
 
 module.exports = (robot) => {
-    robot.hear(/dad/i, {
+    robot.hear(/\bdad\b/i, {
         id: 'dad-jokes'
     }, (res) => {
 


### PR DESCRIPTION
This PR will make heimdall [stop yelling at sloan (et al) when he says stuff about dads inadvertently in restricted channels](https://www.flowdock.com/app/cardforcoin/bifrost/threads/Xm2UeUM6MKMsepu5imCuAWLZ0KA)

Remove the room restriction - this may be temporary, until we
revisit a way to have room restrictions not yell at people who
trigger this kind of listener

Update the regex to only get the word dad