### PR TITLE
Tweak formatting of jobs in schedule list for better readability

### DIFF
--- a/scripts/schedule.js
+++ b/scripts/schedule.js
@@ -37,7 +37,7 @@ const config = {
     replaceText: JSON.parse(
       process.env.HUBOT_SCHEDULE_LIST_REPLACE_TEXT
         ? process.env.HUBOT_SCHEDULE_LIST_REPLACE_TEXT
-        : '{"(@{1,2})":"[$1]","```":"\\n```\\n","#":"[#]","\\n":"\\n>"}',
+        : '{"(@@?)":"[$1]","```":"\\n```\\n","#":"[#]","\\n":"\\n>"}',
     ),
   },
 }
@@ -104,10 +104,10 @@ module.exports = function(robot) {
       // if targetRoom is undefined or blank, show schedule for current room
       // room is ignored when HUBOT_SCHEDULE_DENY_EXTERNAL_CONTROL is set to 1
       rooms = [roomId]
-      outputPrefix = outputPrefix += "THIS flow:\n"
+      outputPrefix += "THIS flow:\n"
     } else if (targetRoom === "all") {
       showAll = true
-      outputPrefix = outputPrefix += "ALL flows:\n"
+      outputPrefix += "ALL flows:\n"
     } else {
       targetRoomId = getRoomIdFromName(msg, robot, targetRoom)
       if (!robotIsInRoom(robot, targetRoomId)) {
@@ -116,7 +116,7 @@ module.exports = function(robot) {
         )
       }
       rooms = [targetRoomId]
-      outputPrefix = outputPrefix += `the ${targetRoom} flow:\n`
+      outputPrefix += `the ${targetRoom} flow:\n`
     }
 
     // split jobs into date and cron pattern jobs
@@ -361,7 +361,7 @@ var isBlank = s => !(s ? s.trim() : undefined)
 
 function isRestrictedRoom(targetRoom, robot, msg) {
   if (config.denyExternalControl === "1") {
-    if (!(msg.message.user.room === targetRoom)) {
+    if (msg.message.user.room !== targetRoom) {
       return true
     }
   }


### PR DESCRIPTION
This PR addresses a couple formatting issues noticed once folks started using the schedule command.

Adjustments made include:
- handle code blocks better with added linebreaks
- visually differentiate between tasks in the list

Other fixes included in this PR are a side effect of finding them while testing: 
- update custom flowdock utilities to not break local dev using the shell adapter 
- fix bug in the `add` command's `isRestrictedRoom` check (pass targetRoomId, not name)
- plus some refactoring based on non-blocking notes from PR #44 

**Block quote every job message, including code blocks, to help differentiate between jobs**

![schedule_list_block_quotes_fixed](https://user-images.githubusercontent.com/8386754/58843536-cba5d480-8627-11e9-9883-c71d4fb44aba.png)


**Show flow name (or "All" or "This") in list header, only show in list items if listing all**

![schedule_list_room_name_conditional](https://user-images.githubusercontent.com/8386754/58843537-cc3e6b00-8627-11e9-91c2-fff9b05c46e6.png)




TODO:
- [x] merge #43 first and rebase this onto updated master
- [x] fine-tune the formatting (including... making markdown work)
