### PR TITLE
Remove workaround for adapter connection bug

### DIFF
--- a/scripts/current-build.js
+++ b/scripts/current-build.js
@@ -46,23 +46,7 @@ function attachToStream(fn) {
 }
 
 module.exports = function(robot) {
-  // Adjust for Flowdock adapter dispatching the connected event too soon.
-  if (robot.adapter.bot && robot.adapter.bot.flows) {
-    robot.adapter.bot.flows(() => {
-      attachToStream(() => {
-        if (robot.adapter.stream) {
-          robot.adapter.stream.on("connected", () =>
-            sendReleaseNotification(robot.adapter),
-          )
-          return true
-        } else {
-          return false
-        }
-      })
-    })
-  } else {
-    sendReleaseNotification(robot)
-  }
+  sendReleaseNotification(robot)
 
   robot.respond(/flows/, response => {
     if (robot.adapter.flows != null) {


### PR DESCRIPTION
We are now using a patched version of the flowdock adapter, which addresses the connection issue that this previously worked around.

With the patched adapter in place, this workaround backfires, waiting for a "connected" event that has already happened

Some more context [here](https://www.flowdock.com/app/cardforcoin/bifrost/threads/DGSlhr8H20sIQ8T17GJtLC_6Z41)