### PR TITLE
Reduce depth of errors logged, to reduce pollution in the logs

### DIFF
--- a/scripts/zeplin-flowdock-integration.ts
+++ b/scripts/zeplin-flowdock-integration.ts
@@ -216,7 +216,7 @@ function checkForNotifications(logger, brain) {
           } catch (err) {
             logger.error(
               `Error handling notification [${action}]}]: ${util.inspect(err, {
-                depth: 4,
+                depth: 0,
               })}`,
             )
           }


### PR DESCRIPTION
Currently the logs are extremely noisy with zeplin-related errors. Reducing the depth to zero still provides sufficient information for now. 

We may want to bump this up again when actively investigating
the zeplin integration issues, but for now shhhhhhhhhh 🙏 