### PR TITLE
Change value in config map to string

### DIFF
--- a/k8s/hubot-deployment.yaml
+++ b/k8s/hubot-deployment.yaml
@@ -91,7 +91,7 @@ spec:
                   name: heimdall-hubot
                   key: zoom_api_secret
             - name: ZOOM_EXPECTED_MEETING_DURATION
-              value: 60
+              value: "60"
           ports:
             - containerPort: 8080
           resources:


### PR DESCRIPTION
The code already assumes it could be a string, and [handles parsing it](https://github.com/thesis/heimdall/blob/165dd0f34daf6734282292fa0ee932f339023a55/scripts/zoom.js#L22-L23) to int.

Fixes bug documented [here](https://www.flowdock.com/app/cardforcoin/bifrost/threads/o1chx87Hn5GfCNJRRhljsE28EQU)

**NOTE: 
This fix has already been applied via running `kubectl apply --record -f k8s/hubot-deployment.yaml` on a local edit. This PR is for keeping the repo in sync only**