### PR TITLE
Refactor suggest to async await

### DIFF
--- a/scripts/suggest.js
+++ b/scripts/suggest.js
@@ -136,7 +136,7 @@ module.exports = function(robot) {
       // construct formatted thread link
       let alertThreadReference = `[${alertRoomName}](${flowdock.URLs.thread})`
         .replace(/{flowPath}/, alertRoomPath)
-        .replace(/{threadId}/, threadId)
+        .replace(/{threadId}/, alertThreadId)
       // then respond in source suggestion thread with formatted thread link
       res.send(
         `Thanks for the suggestion! We'll be discussing it further in ${alertThreadReference}, feel free to join us there.`,


### PR DESCRIPTION
This PR refactors the suggest script to use async/ await, and flatten the control flow a bit for readability.

It's the output of pairing w/ @Shadowfiend during the Engineering Experience onsite 💟 

TODO:
- [x] run locally and make sure nothing borked