### PR TITLE
Convert int value in deployments file to string

### DIFF
--- a/k8s/hubot-deployment.yaml
+++ b/k8s/hubot-deployment.yaml
@@ -34,7 +34,7 @@ spec:
                   name: heimdall-hubot
                   key: host
             - name: HUBOT_SCHEDULE_DEBUG
-              value: 1
+              value: "1"
             - name: RELEASE_NOTIFICATION_ROOM
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Note: this yaml has already been applied to the deployed build. This PR is just to keep the repo in sync.

This [fixes a type error in applying this record](https://www.flowdock.com/app/cardforcoin/bifrost/threads/0TnbQ0WGlmIsw9ubEQVvZ_2ilWw)

This value turns on schedule debug logging in production, intentionally
We are in the process of overhauling the schedule command, and will
be sharing these utilities with the remind command
Since the redis brain does not persist between builds in local dev
it is helpful to see more logging in production, at least for a few
builds while we are iterating on these commands