### PR TITLE
Update hubot-shipit to use updated hubot 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -702,8 +702,8 @@
       }
     },
     "hubot-shipit": {
-      "version": "github:takouhai/hubot-shipit#955703ae5e00412bedec5eea0070d4a66e10fc93",
-      "from": "github:takouhai/hubot-shipit#955703ae5e00412bedec5eea0070d4a66e10fc93"
+      "version": "github:kb0rg/hubot-shipit#cb51773ede8c3bf8fff409cb110936f158801d83",
+      "from": "github:kb0rg/hubot-shipit#cb51773ede8c3bf8fff409cb110936f158801d83"
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "hubot-reload": "0.0.2",
     "hubot-rules": "^0.1.2",
     "hubot-scripts": "^2.17.2",
-    "hubot-shipit": "github:takouhai/hubot-shipit#955703ae5e00412bedec5eea0070d4a66e10fc93",
+    "hubot-shipit": "github:kb0rg/hubot-shipit#cb51773ede8c3bf8fff409cb110936f158801d83",
     "jsonwebtoken": "~8.3.0",
     "lodash": "^4.17.14",
     "moment": "^2.24.0",


### PR DESCRIPTION
This PR is all about making the following warning go away:
```
npm WARN hubot-shipit@0.2.0 requires a peer of hubot@2.x but none is installed. You must install peer dependencies yourself.
```

The fork of shipit we were using was a few commits behind the original package, missing a hubot version update and therefore throwing these warnings.

I forked the canonical hubot-shipit repo to get the latest updates, and merged in the image updates from the fork we were already using for Heimdall. This PR points Heimdall at my fork.

