### PR TITLE
Fix bug in circle deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
       - run:
           name: Load Docker image
           command: |
-            docker load -i /tmp/heimdall/docker-images/heimdall-{$CIRCLE_BUILD_NUM}.tar
+            docker load -i /tmp/heimdall/docker-images/heimdall-$CIRCLE_BUILD_NUM.tar
       - run:
           name: Set up GCP
           command: |


### PR DESCRIPTION
This fixes a bug in the deploy job's `docker load` command. 
The string interpolation for the circle build number in the docker image path was busted.

See [failed deploy job here](https://circleci.com/gh/thesis/heimdall/359)