### PR TITLE
Actually fix the bug in the circle deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
             mkdir -p /tmp/heimdall/docker-images/
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               echo Saving build for master branch.
-              docker save -o /tmp/heimdall/docker-images/heimdall-$CIRCLE_BUILD_NUM.tar gcr.io/$PROJECT_NAME/heimdall:$CIRCLE_BUILD_NUM
+              docker save -o /tmp/heimdall/docker-images/heimdall-${CIRCLE_BUILD_NUM}.tar gcr.io/$PROJECT_NAME/heimdall:$CIRCLE_BUILD_NUM
             else
               echo Not saving build for development branch.
             fi


### PR DESCRIPTION
This fixes the bug that #125 was addressing

To test it, I added a temporary step to the build step in the circle config, running both the `docker save` and `docker load` lines that typically only run on master. [This successful build](https://circleci.com/gh/thesis/heimdall/365) verifies it. 