### PR TITLE
Reformat display of remind and schedule jobs

### DIFF
--- a/scripts/remind.js
+++ b/scripts/remind.js
@@ -60,12 +60,6 @@ module.exports = function(robot) {
       team: "@team, ",
     }
 
-    // debug
-    // console.log(
-    //   `\n\n>>>remind command: what's in msg? \n${require("util").inspect(msg)}`,
-    // )
-    //
-
     let who = msg.match[1]
     let message = whoToTag[who] || ""
 


### PR DESCRIPTION
Closes #133 

This is a minor enhancement to both `remind` and `schedule` commands. It de-emphasizes the job id, and uses a more human-readable datetime format in job display.

There is some context toward the end of [this thread](https://www.flowdock.com/app/cardforcoin/playground/threads/7ai41FiC5zfSr2zxmJ3GZLWMDK5); this is an incremental step toward (not a replacement for)bigger usability improvements (eg adding user-based timezone functionality).

**reminder list formatting: before and after**
<img width="509" alt="Screen Shot 2019-10-01 at 11 31 21 AM" src="https://user-images.githubusercontent.com/8386754/65990232-11d93c00-e440-11e9-91ec-24b6d27135ac.png">
