### PR TITLE
Entering the ninth circle to fix the bugs in the deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,19 +10,17 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          name: Create Directory and Save Build Number
-          command: |
-            mkdir -p /tmp/heimdall/docker-images/
-            echo $CIRCLE_BUILD_NUM > /tmp/heimdall/docker-images/BUILD
-      - run:
           name: Build Docker Image and Run Tests
           command: |
+            echo $CIRCLE_BUILD_NUM > BUILD
             docker build . -t gcr.io/$PROJECT_NAME/heimdall:$CIRCLE_BUILD_NUM
       - run:
           name: Save build
           command: |
+            mkdir -p /tmp/heimdall/docker-images/
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              echo Saving build for master branch.
+              echo Saving build and build tag for master branch.
+              cp ./BUILD /tmp/heimdall/docker-images/BUILD
               docker save -o /tmp/heimdall/docker-images/heimdall.tar gcr.io/$PROJECT_NAME/heimdall:$CIRCLE_BUILD_NUM
             else
               echo Not saving build for development branch.


### PR DESCRIPTION
This addresses the bugs created in the deploy step in PR #108 -- and improperly "fixed" (by me) in PRs #125 and #126 

Because the bugs are in the push and deploy steps, which we only run on merges to master, I can not say with 💯 certainty  that this PR is bug-free. However, a [number of tests were run on a sandbox branch](https://circleci.com/gh/thesis/heimdall/tree/really-this-time-bugfix-the-circle-deploy-job-bugfix) to verify the assumptions made in this PR.