### PR TITLE
Hammering at the deploy step. Again.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/heimdall
+      - checkout
       - setup_remote_docker:
           docker_layer_caching: true
       - run:


### PR DESCRIPTION
This checks out the repo, which is a necessary step for run commands that follow.