### PR TITLE
Fix bug getting Flowdock session for users command

### DIFF
--- a/scripts/flowdock-admin.js
+++ b/scripts/flowdock-admin.js
@@ -42,7 +42,7 @@ module.exports = function(robot) {
       if (notUsingFlowdock(robot.adapter, response)) {
         return
       }
-      const session = new flowdock.BasicAuthSession(apiToken)
+      const session = new flowdock.Session(apiToken)
       session.get("/users/", {}, (err, body, usersResponse) => {
         if (err == null) {
           response.send(


### PR DESCRIPTION
This addresses a bug I ran into while poking around the flowdock api users endpoint with Heimdall's help.

Fixes a broken import that was causing the session instantiation to fail.