### PR TITLE
Fix reminder and schedule job display formatting

### DIFF
--- a/lib/schedule-util.js
+++ b/lib/schedule-util.js
@@ -361,7 +361,7 @@ function formatJobForMessage(
   jobId,
   jobMessage,
   jobRoom,
-  jobThreadID,
+  jobThreadId,
 ) {
   let text = ""
   let roomDisplayText = ""
@@ -380,7 +380,7 @@ function formatJobForMessage(
     : "Private Message"
   roomDisplayText = `(to ${jobRoomDisplayName})`
 
-  if (jobThreadID && jobRoom) {
+  if (jobThreadId && jobRoom) {
     let jobFlow = getRoomInfoFromIdOrName(robotAdapter, jobRoom)
     if (!jobFlow) {
       // this is probably local dev in the shell adapter
@@ -388,9 +388,10 @@ function formatJobForMessage(
       robot.logger.error(`Could not get flow info from: ${jobRoom}.`)
     } else {
       let jobRoomPath = robotAdapter.flowPath(jobFlow)
+      let encodedThreadId = encodeURIComponent(jobThreadId).replace(/-/g, "%2D")
       roomDisplayText = `(to [thread in ${jobRoomDisplayName}](${flowdock.URLs.thread}))`
         .replace(/{flowPath}/, jobRoomPath)
-        .replace(/{threadId}/, jobThreadID)
+        .replace(/{threadId}/, encodedThreadId)
     }
   }
 


### PR DESCRIPTION
This fixes a couple formatting errors discovered after release of build 437

The three issues [demonstrated here](https://www.flowdock.com/app/cardforcoin/bifrost/threads/af8GTg0T4uLyMaBEzotGlK64rIK) fixed in this PR are:
- The trailing parenthesis has been restored around the "(to `<flow name or link>`)" 
- The flow name is restored for jobs that don't have a threadId (eg `schedule` command jobs)
- Dashes in the threadId have been encoded so that they don't break link markdown

~~The third issue, as Antonio mentioned in [this thread](https://www.flowdock.com/app/cardforcoin/main/threads/Podp1dT1JfdxwxCa0um-DlGAv--), appears to be an issue with Flowdock's handling of a url with trailing dashes.~~ 
[EDIT: updated this description after Antonio suggested addressing this issue by url encoding the dashes]

Playground tests of this branch [are here](https://www.flowdock.com/app/cardforcoin/playground/threads/bHRypdFKtD9JNWcefy20tsxYY4v)