### PR TITLE
Fix bug in constructing reminderURL for formatted reminder display

### DIFF
--- a/lib/schedule-util.js
+++ b/lib/schedule-util.js
@@ -445,7 +445,7 @@ function formatJobForMessage(
         ? flowdock.URLs.thread
         : flowdock.URLs.messageDetail
 
-      reminderURL
+      reminderURL = reminderURL
         .replace(/{flowPath}/, jobRoomPath)
         .replace(/{messageId}|{threadId}/, encodedId)
 


### PR DESCRIPTION
This fixes a bug introduced in PR #157 

The refactor done to the `reminderURL` was missing the necessary reassignment of the updated string to the `reminderURL`  variable (since strings are immutable, string replace does not edit the existing string in place but returns a new string).

Verified this works for reminders using both [`threadID` in the url](https://www.flowdock.com/app/cardforcoin/playground/threads/1Bev_mdgcOKY_Wdhg98JIiwna9I) and [those using `messageId`](https://www.flowdock.com/app/cardforcoin/ops/messages/353816)