### PR TITLE
Update zoom app link to use pmi instead of meeting id

### DIFF
--- a/lib/zoom.ts
+++ b/lib/zoom.ts
@@ -199,14 +199,14 @@ class Account {
             host_video: true,
             participant_video: true,
             waiting_room: false,
-            use_pmi: true,
+            use_pmi: false,
           },
         },
         { params: { access_token: this.token } },
       ),
       meeting: Meeting = response.data
 
-    meeting.app_url = URLs.appJoin.replace(/{meetingId}/, meeting.pmi)
+    meeting.app_url = URLs.appJoin.replace(/{meetingId}/, meeting.id)
     return [meeting, this.email]
   }
 


### PR DESCRIPTION
Closes #128 

This addresses a bug discussed [here](https://www.flowdock.com/app/cardforcoin/bifrost/threads/wtYlx_oaBZaRnGJ7MJe7-mOLel8), in which users were sometimes seeing an "Invalid meeting id" error. 

~~This updates the app link to use the account pmi instead of the meeting id, and creates the meeting with the "use_pmi" flag set to true.~~

This ensures that the pmi is *not* used in the creation of join meeting links, in favor of a meeting id instead. 