### PR TITLE
Add a document with info on migrating Heimdall to a new cluster

### DIFF
--- a/docs/migrating-heimdall.md
+++ b/docs/migrating-heimdall.md
@@ -17,7 +17,7 @@ useful reference point for any future migrations.
 - Source GCP Project: `cfc-production-deprecated`
 - Target GCP Project: `thesis-ops`
 - Source Cluster: `gke_cfc-production_us-east4-c_heimdall`
-- Target Cluser: `gke_thesis-ops-2748_us-central1_heimdall` (not yet created)
+- Target Cluser: `gke_thesis-ops-2748_us-central1_thesis-ops`
 
 ### Kube Objects
 


### PR DESCRIPTION
Closes #147, Closes #148 

This is steps one and two of document that we'll add to until [the Heimdall migration](https://github.com/thesis/heimdall/issues/129) is complete. This doc is meant to stay in the repo to assist in any future migrations.

This covers the steps involved in migrating the secrets and redis brain to a new GCP kube cluster, and gives some additional context around permissions and config for the kube and GCP tools used in the process.