### PR TITLE
At last, the last url command

### DIFF
--- a/lib/schedule-util.js
+++ b/lib/schedule-util.js
@@ -120,8 +120,8 @@ function test(inputString) {
 }
 
 /**
- * Given a robot brain, a string (either "self" or the job id of another
- * scheduled job), and the currently running job object, returns:
+ * Given a string (either "self" or the job id of another scheduled job), a
+ * robot brain, and the currently running job object, returns:
  * - the url of the posted message for the previous invocation of the job
  * specified in the input string,
  * or


### PR DESCRIPTION
Closes #72 

This PR adds an enhancement to the `schedule` command recurring jobs, allowing the user to create a link from one recurring job to another.

When creating a new `schedule` job with the cron syntax, the job's message may refer to an existing schedule job using the template string format introduced in PR #173 , with the new `last-url` command introduced here. 

For example, this command:
`\schedule add fold "0 11 * * 1-5" Don't forget to post your [Fold standup]({{last-url:4121}}) if you haven't already!`

would post the following, at 11am UTC, in the Fold flow (if it ran today, Dec 20, 2019),:
"Don't forget to post your [Fold standup](https://www.flowdock.com/app/cardforcoin/fold-flow/threads/mzPHzkTKqrs3hqeK1QR6hs2D9v0) if you haven't already!"

TODO:
- [x] Merge PR #177 
- [x] Rebase this PR against the updated master branch.