### PR TITLE
Fix bug setting lastUrl if no metadata exists

### DIFF
--- a/lib/schedule-util.js
+++ b/lib/schedule-util.js
@@ -673,20 +673,12 @@ function postMessageCallback(robot, runningJob, messageText) {
     if (err) {
       // Send job via adapter if there's an error posting via API. Since we
       // won't get back a thread_id to save into the lastUrl, we clear the
-      // lastUrl param currently set on the recurring job, and update the saved
-      // job.
+      // lastUrl param currently set on the recurring job.
 
       robot.logger.error(
         `Problem posting scheduled job message via Flowdock API: %o`,
         err,
       )
-
-      // Update the job in memory, and ensure metadata exists
-      if (!!runningJob.metadata) {
-        runningJob.metadata.lastUrl = lastUrl
-      } else {
-        runningJob.metadata = { lastUrl: lastUrl }
-      }
 
       const messageEnvelope = {
         user: runningJob.user,
@@ -699,7 +691,7 @@ function postMessageCallback(robot, runningJob, messageText) {
 
       robot.send(messageEnvelope, messageText)
     } else if (res && res.flow && res.thread_id) {
-      // Build the url and save it on the job.
+      // Build the url.
       let lastPostedFlow = getRoomInfoFromIdOrName(robot.adapter, res.flow)
       if (lastPostedFlow) {
         threadId = res.thread_id // We may need this from `robot.adapter.receive()`
@@ -709,26 +701,12 @@ function postMessageCallback(robot, runningJob, messageText) {
           .replace(/{flowPath}/, lastPostedFlowPath)
           .replace(/{messageId}|{threadId}/, encodedId)
 
-        // Update the job in memory, and ensure metadata exists
-        if (!!runningJob.metadata) {
-          runningJob.metadata.lastUrl = lastUrl
-        } else {
-          runningJob.metadata = { lastUrl: lastUrl }
-        }
-
         logMessage = "Updated job's last url after posting latest occurrence"
       }
     } else {
       // Something went wrong getting a thread_id back from the API for the job
       // that just fired, even though the job's message posted without error.
-      // Clear the job's lastUrl param, and save the updated job.
-
-      // Update the job in memory, and ensure metadata exists
-      if (!!runningJob.metadata) {
-        runningJob.metadata.lastUrl = lastUrl
-      } else {
-        runningJob.metadata = { lastUrl: lastUrl }
-      }
+      // Clear the job's lastUrl param.
 
       robot.logger.info(
         `Could not get thread_id for schedule job # ${runningJob.id}`,
@@ -744,6 +722,13 @@ function postMessageCallback(robot, runningJob, messageText) {
       // If we got a threadId from the API, include it as metadata
       messageObj.metadata = { thread_id: threadId }
       robot.adapter.receive(messageObj)
+    }
+
+    // Update the job in memory, and ensure metadata exists
+    if (!!runningJob.metadata) {
+      runningJob.metadata.lastUrl = lastUrl
+    } else {
+      runningJob.metadata = { lastUrl: lastUrl }
     }
 
     // Update the job in brain and log the update.


### PR DESCRIPTION
This fixes a bug observed in the production logs (see [thread](https://www.flowdock.com/app/cardforcoin/bifrost/threads/KL8aXDUSu3vCRHTW1fh8DaE7OAA)): `Cannot set property 'lastUrl' of null`

This bug has not been observed in local testing.

