### PR TITLE
Enable the use of multiple template strings in a scheduled job

### DIFF
--- a/lib/schedule-util.js
+++ b/lib/schedule-util.js
@@ -184,15 +184,12 @@ function processTemplateString(message, robotBrain, runningJob) {
       `Could not process template string in message: ${error.message}`,
     )
   }
-  if (templateString.length > 0) {
-    return processTemplateString(
-      message.substring(templateString.length + templateStringMatch.index),
-      robotBrain,
-      runningJob,
-    )
-  } else {
-    return message.replace(templateString, templateStringFormatted)
-  }
+
+  return processTemplateString(
+    message.replace(templateString, templateStringFormatted),
+    robotBrain,
+    runningJob,
+  )
 }
 
 function scheduleNewJob(


### PR DESCRIPTION
After releasing the `last-url` template string command in PR #180 we realized that we hadn't allowed for the user to enter multiple template string commands in one message.

This PR corrects that.