### PR TITLE
Switch order of zoom links

### DIFF
--- a/scripts/zoom.js
+++ b/scripts/zoom.js
@@ -135,7 +135,7 @@ module.exports = function(robot) {
             `Created meeting: ${meeting.id}: using account for ${zoomUserEmail}`,
           )
           res.send(
-            `All set; open in [the app](${meeting.app_url}) or [your browser](${meeting.join_url})!`,
+            `All set; open in [your browser](${meeting.join_url}) or [the app](${meeting.app_url})!`,
           )
           return meeting
         })


### PR DESCRIPTION
This is a verrrrrrrrrrry quick workaround for an issue we're seeing on iOs devices
The Flowdock app on ios, for reasons unknown to me, only allows the first link in a message to work

The app link does not work on ios because... reasons
So this way we offer the web link first, enabling ios Flowdock users to use Zoom meeting links.