### PR TITLE
Reduce depth of objects in logs

### DIFF
--- a/lib/zoom.ts
+++ b/lib/zoom.ts
@@ -55,7 +55,9 @@ async function getMeetingDetails(sessionToken: string, meetingId: string) {
     )
     return response.data
   } catch (err) {
-    throw `Something went wrong getting meeting details: ${util.inspect(err)}.`
+    throw `Something went wrong getting meeting details: ${util.inspect(err, {
+      depth: 0,
+    })}.`
   }
 }
 

--- a/scripts/suggest.js
+++ b/scripts/suggest.js
@@ -133,6 +133,7 @@ module.exports = function(robot) {
         throw new Error(
           `Did not get thread id from post message response: ${util.inspect(
             postResponse,
+            { depth: 0 },
           )}`,
         )
       }
@@ -147,7 +148,9 @@ module.exports = function(robot) {
       )
     } catch (err) {
       robot.logger.error(
-        `Failed to send user suggestion to target flow: ${util.inspect(err)}`,
+        `Failed to send user suggestion to target flow: ${util.inspect(err, {
+          depth: 0,
+        })}`,
       )
       res.send(
         `Something went wrong trying to post your suggestion. Please ask your friendly human robot-tender to look into it.`,

--- a/scripts/zoom.js
+++ b/scripts/zoom.js
@@ -67,6 +67,7 @@ function watchMeeting(meeting) {
           reject(
             `Something went wrong setting up START watch interval: ${util.inspect(
               err,
+              { depth: 0 },
             )}`,
           )
           return
@@ -96,6 +97,7 @@ function watchMeeting(meeting) {
             reject(
               `Something went wrong setting up END watch interval: ${util.inspect(
                 err,
+                { depth: 0 },
               )}`,
             )
             return
@@ -120,7 +122,9 @@ module.exports = function(robot) {
       .getSession(zoomApiKey, zoomApiSecret, MEETING_DURATION_TIMEOUT_DELAY)
       .then(session => (ZOOM_SESSION = session))
       .catch(err => {
-        robot.logger.error("Failed to set up Zoom session:", util.inspect(err))
+        robot.logger.error(
+          `Failed to set up Zoom session: ${util.inspect(err, { depth: 0 })}`,
+        )
       })
 
     robot.respond(/zoom/, res => {
@@ -140,8 +144,9 @@ module.exports = function(robot) {
         })
         .catch(err => {
           robot.logger.error(
-            "Failed to fetch next available meeting:",
-            util.inspect(err),
+            `Failed to fetch next available meeting: ${util.inspect(err, {
+              depth: 0,
+            })}`,
           )
           res.send("Uh-oh, there was an issue finding an available meeting :(")
         })
@@ -176,8 +181,9 @@ module.exports = function(robot) {
             })
             .catch(err => {
               robot.logger.error(
-                `Failed to fetch meeting details for ${meeting.id}. ERR:`,
-                util.inspect(err),
+                `Failed to fetch meeting details for ${
+                  meeting.id
+                }. ERR: ${util.inspect(err, { depth: 0 })}`,
               )
               // We assume the meeting still happened, so reply (but without `@`)
               res.send(


### PR DESCRIPTION
These puppies are [painful to try to read when they end up in stackdriver](https://console.cloud.google.com/logs/viewer?authuser=1&organizationId=383679265266&project=thesis-ops-2748&minLogLevel=0&expandAll=false&timestamp=2020-02-20T04%3A02%3A23.873000000Z&customFacets&limitCustomFacetWidth=true&interval=CUSTOM&resource=k8s_cluster%2Flocation%2Fus-central1%2Fcluster_name%2Fthesis-ops&scrollTimestamp=2020-02-14T23%3A14%3A36.256699430Z&advancedFilter=resource.type%3D%22container%22%0Aresource.labels.cluster_name%3D%22thesis-ops%22%0Aresource.labels.container_name%3D%22hubot%22&dateRangeEnd=2020-02-14T23%3A20%3A50.000Z&dateRangeStart=2020-02-14T20%3A10%3A50.000Z); they get split up into one log per line.

We've added this depth restriction in a couple other places already - but so far seem to only add it when we run into the issue. 

In this PR we seek out any other logged object and add this setting.