### PR TITLE
Bump help version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1933,8 +1933,8 @@
       "integrity": "sha512-4kuR04lULoDDra/Z7B/rgMQMZW531Ve5hwhd8xNOKAl8e1cb5bZNqVpGFYF174eYcN54+RZuWQFHsntjvczyag=="
     },
     "hubot-even-better-help": {
-      "version": "github:thesis/hubot-even-better-help#c5398810c58a0cda67ac7c4eacdabe7e333c78fb",
-      "from": "github:thesis/hubot-even-better-help#c5398810c58a0cda67ac7c4eacdabe7e333c78fb",
+      "version": "github:thesis/hubot-even-better-help#3192eedf2a0f11dd0b5fa736e0b9033741a59050",
+      "from": "github:thesis/hubot-even-better-help#3192eedf2a0f11dd0b5fa736e0b9033741a59050",
       "requires": {
         "coffeescript": "~2.4",
         "stopwords": "^0.0.5"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "hubot": "^3.3.2",
     "hubot-circleci": "^0.8.1",
     "hubot-diagnostics": "^1.0.0",
-    "hubot-even-better-help": "github:thesis/hubot-even-better-help#c5398810c58a0cda67ac7c4eacdabe7e333c78fb",
+    "hubot-even-better-help": "github:thesis/hubot-even-better-help#3192eedf2a0f11dd0b5fa736e0b9033741a59050",
     "hubot-gif-locker": "^1.0.7",
     "hubot-redis-brain": "^1.0.0",
     "hubot-reload-flowdock": "github:thesis/hubot-flowdock#7370c583068eceee8482a066d75d9f30a98e1745",


### PR DESCRIPTION
This updates Heimdall to use an update to our fork of the `hubot-even-better-help` package.

The previous version was pointing at a branch that was still in [a draft PR, which has since merged](https://github.com/thesis/hubot-even-better-help/pull/4).

Updates include revisions to how the robot name is handled in help descriptions versus commands, and a spacing adjustment to align with the way the standard help package behaves.