### PR TITLE
Disintermediation: Include host key in zoom meeting message

### DIFF
--- a/scripts/zoom.js
+++ b/scripts/zoom.js
@@ -133,12 +133,16 @@ module.exports = function (robot) {
         return
       }
       ZOOM_SESSION.nextAvailableMeeting()
-        .then(([meeting, zoomUserEmail]) => {
+        .then(([meeting, zoomUserEmail, , hostKey]) => {
           robot.logger.info(
-            `Created meeting: ${meeting.id}: using account for ${zoomUserEmail}`,
+            `Created meeting: ${meeting.id}: using account for ${zoomUserEmail}, host key ${hostKey}.`,
           )
           res.send(
-            `All set; open in [your browser](${meeting.join_url}) or [the app](${meeting.app_url})!`,
+            `All set${
+              typeof hostKey !== "undefined" ? " with host key " + hostKey : ""
+            }; open in [your browser](${meeting.join_url}) or [the app](${
+              meeting.app_url
+            })!`,
           )
           return meeting
         })


### PR DESCRIPTION
> [**Disintermediation** is the removal of intermediaries in economics from a supply chain, or "cutting out the middlemen" in connection with a transaction or a series of transactions.[1] Instead of going through traditional distribution channels, which had some type of intermediary (such as a distributor, wholesaler, broker, or agent), companies may now deal with customers directly, for example via the Internet.](https://en.wikipedia.org/wiki/Disintermediation)

If the host key is unavailable, the message will be as before. The host
key allows the users to share screen and do other things that typically
require the host to be present.

Host keys allow meeting takeover, but only for meetings whose host is not
present. They don't really allow any other account interactions that I'm
aware of. As such, it seems reasonably safe to include them in the internally
public chat messages used for zoom.