### PR TITLE
Valkyrie Hostname: Update static IP for web ingress

### DIFF
--- a/infrastructure/kube/thesis-ops/heimdall-web-ingress.yaml
+++ b/infrastructure/kube/thesis-ops/heimdall-web-ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.global-static-ip-name: heimdall-web-ip
+    kubernetes.io/ingress.global-static-ip-name: valkyrie-web-ip
   name: heimdall-web-ingress
 spec:
   backend:

--- a/infrastructure/kube/thesis-ops/heimdall-web-ingress.yaml
+++ b/infrastructure/kube/thesis-ops/heimdall-web-ingress.yaml
@@ -2,9 +2,12 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   annotations:
+    kubernetes.io/ingress.allow-http: "false"
     kubernetes.io/ingress.global-static-ip-name: valkyrie-web-ip
   name: heimdall-web-ingress
 spec:
+  tls:
+  - secretName: thesis-co-cloudflare-origin-cert
   backend:
     serviceName: heimdall-http-service
     servicePort: 8080


### PR DESCRIPTION
The new IP is owned by the correct (thesis-ops) project, and is being hooked up to a proper subdomain in Cloudflare. The kube secrets map has been updated to point to that subdomain so that once this config is applied the valkyrie pods can be kicked and pick up the updated hostname info.