### PR TITLE
Valkyrie Kubed: Rename kube resources to valkyrie-*

### DIFF
--- a/infrastructure/kube/thesis-ops/create.sh
+++ b/infrastructure/kube/thesis-ops/create.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-kubectl apply --record -f "${BASH_SOURCE%/*}/heimdall-redis-stateful-set.yaml"
-kubectl apply --record -f "${BASH_SOURCE%/*}/heimdall-redis-service.yaml"
-kubectl apply --record -f "${BASH_SOURCE%/*}/heimdall-hubot-deployment.yaml"
-kubectl apply --record -f "${BASH_SOURCE%/*}/heimdall-http-service.yaml"
-kubectl apply --record -f "${BASH_SOURCE%/*}/heimdall-web-ingress.yaml"
+kubectl apply --record -f "${BASH_SOURCE%/*}/valkyrie-redis-stateful-set.yaml"
+kubectl apply --record -f "${BASH_SOURCE%/*}/valkyrie-redis-service.yaml"
+kubectl apply --record -f "${BASH_SOURCE%/*}/valkyrie-hubot-deployment.yaml"
+kubectl apply --record -f "${BASH_SOURCE%/*}/valkyrie-http-service.yaml"
+kubectl apply --record -f "${BASH_SOURCE%/*}/valkyrie-web-ingress.yaml"

--- a/infrastructure/kube/thesis-ops/update-image.sh
+++ b/infrastructure/kube/thesis-ops/update-image.sh
@@ -26,8 +26,8 @@ ssh utilitybox << EOF
   echo "gcloud container clusters get-credentials $GOOGLE_PROJECT_NAME --region $GOOGLE_REGION --internal-ip --project=$GOOGLE_PROJECT_ID"
   gcloud container clusters get-credentials $GOOGLE_PROJECT_NAME --region $GOOGLE_REGION --internal-ip --project=$GOOGLE_PROJECT_ID
   echo ">>>>>>FINISH Download Kube Creds FINISH>>>>>>"
-  echo "<<<<<<START Run Heimdall Deployment START<<<<<<"
-  kubectl set image deployment/heimdall-hubot-deployment hubot=$GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/valkyrie:$BUILD_TAG
-  echo ">>>>>>FINISH Run Heimdall Deployment FINISH>>>>>>"
+  echo "<<<<<<START Run Valkyrie Deployment START<<<<<<"
+  kubectl set image deployment/valkyrie-hubot-deployment hubot=$GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/valkyrie:$BUILD_TAG
+  echo ">>>>>>FINISH Run Valkyrie Deployment FINISH>>>>>>"
 
 EOF

--- a/infrastructure/kube/thesis-ops/valkyrie-http-service.yaml
+++ b/infrastructure/kube/thesis-ops/valkyrie-http-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: heimdall-http-service
+  name: valkyrie-http-service
   labels:
     app: hubot
 spec:

--- a/infrastructure/kube/thesis-ops/valkyrie-hubot-deployment.yaml
+++ b/infrastructure/kube/thesis-ops/valkyrie-hubot-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: heimdall-hubot-deployment
+  name: valkyrie-hubot-deployment
   labels:
     app: hubot
 spec:
@@ -16,70 +16,70 @@ spec:
     spec:
       containers:
         - name: hubot
-          # image: gcr.io/thesis-ops-2748/heimdall:USE_CIRCLE_CI_BUILDS
+          # image: gcr.io/thesis-ops-2748/valkyrie:USE_CIRCLE_CI_BUILDS
           env:
             - name: HUBOT_FLOWDOCK_API_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: heimdall-hubot
+                  name: valkyrie-hubot
                   key: flowdock_token
             - name: HUBOT_MATRIX_USER
               value: "@valkyrie:thesis.co"
             - name: HUBOT_MATRIX_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: heimdall-hubot
+                  name: valkyrie-hubot
                   key: matrix_valkyrie_password
             - name: HUBOT_MATRIX_HOST_SERVER
               value: "https://thesisco.ems.host"
             - name: HUBOT_HOST
               valueFrom:
                 secretKeyRef:
-                  name: heimdall-hubot
+                  name: valkyrie-hubot
                   key: host
             - name: HUBOT_SCHEDULE_DEBUG
               value: "1"
             - name: RELEASE_NOTIFICATION_ROOM
               valueFrom:
                 secretKeyRef:
-                  name: heimdall-hubot
-                  key: heimdall_alert_flow
+                  name: valkyrie-hubot
+                  key: valkyrie_alert_flow
             - name: SUGGESTION_ALERT_ROOM # Name of room for suggestion posts
               valueFrom:
                 secretKeyRef:
-                  name: heimdall-hubot
-                  key: heimdall_alert_flow
+                  name: valkyrie-hubot
+                  key: valkyrie_alert_flow
             - name: REDIS_URL
-              value: $(HEIMDALL_REDIS_SERVICE_PORT)
+              value: $(VALKYRIE_REDIS_SERVICE_PORT)
             - name: GITHUB_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: heimdall-hubot
+                  name: valkyrie-hubot
                   key: github_client_id
             - name: GITHUB_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: heimdall-hubot
+                  name: valkyrie-hubot
                   key: github_client_secret
             - name: IMGFLIP_API_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: heimdall-hubot
+                  name: valkyrie-hubot
                   key: imgflip_api_username
             - name: IMGFLIP_API_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: heimdall-hubot
+                  name: valkyrie-hubot
                   key: imgflip_api_password
             - name: ZOOM_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: heimdall-hubot
+                  name: valkyrie-hubot
                   key: zoom_api_key
             - name: ZOOM_API_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: heimdall-hubot
+                  name: valkyrie-hubot
                   key: zoom_api_secret
             - name: ZOOM_EXPECTED_MEETING_DURATION
               value: "60"

--- a/infrastructure/kube/thesis-ops/valkyrie-redis-service.yaml
+++ b/infrastructure/kube/thesis-ops/valkyrie-redis-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: heimdall-redis-service
+  name: valkyrie-redis-service
 spec:
   selector:
     app: redis

--- a/infrastructure/kube/thesis-ops/valkyrie-redis-stateful-set.yaml
+++ b/infrastructure/kube/thesis-ops/valkyrie-redis-stateful-set.yaml
@@ -2,12 +2,12 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: heimdall-redis-set
+  name: valkyrie-redis-set
   labels:
     app: redis
 spec:
   replicas: 1
-  serviceName: heimdall-redis-service
+  serviceName: valkyrie-redis-service
   selector:
     matchLabels:
       app: redis
@@ -32,10 +32,10 @@ spec:
             - echo "dir /redis-master-data" | redis-server -
           volumeMounts:
             - mountPath: /redis-master-data
-              name: heimdall-data
+              name: valkyrie-data
   volumeClaimTemplates:
     - metadata:
-        name: heimdall-data
+        name: valkyrie-data
       spec:
         accessModes: ["ReadWriteOnce"]
         resources:

--- a/infrastructure/kube/thesis-ops/valkyrie-web-ingress.yaml
+++ b/infrastructure/kube/thesis-ops/valkyrie-web-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -8,6 +8,8 @@ metadata:
 spec:
   tls:
   - secretName: thesis-co-cloudflare-origin-cert
-  backend:
-    serviceName: valkyrie-http-service
-    servicePort: 8080
+  defaultBackend:
+    service:
+      name: valkyrie-http-service
+      port:
+        number: 8080

--- a/infrastructure/kube/thesis-ops/valkyrie-web-ingress.yaml
+++ b/infrastructure/kube/thesis-ops/valkyrie-web-ingress.yaml
@@ -4,10 +4,10 @@ metadata:
   annotations:
     kubernetes.io/ingress.allow-http: "false"
     kubernetes.io/ingress.global-static-ip-name: valkyrie-web-ip
-  name: heimdall-web-ingress
+  name: valkyrie-web-ingress
 spec:
   tls:
   - secretName: thesis-co-cloudflare-origin-cert
   backend:
-    serviceName: heimdall-http-service
+    serviceName: valkyrie-http-service
     servicePort: 8080


### PR DESCRIPTION
This required migrating the redis data to a new stateful set persistent
volume, since the rename of the resource also meant the volume clain
would claim a new persistent volume.

All of this has already been done, and the old resources have been
deleted.

The web ingress was also updated to a stable k8s.io-namespace version
of the ingress spec format.