### PR TITLE
Authily Threaded: Update github auth command to reply in-thread

### DIFF
--- a/scripts/github-auth.ts
+++ b/scripts/github-auth.ts
@@ -85,7 +85,7 @@ export = function setupGitHubAuth(robot: Robot) {
       }
       robot.brain.set(PENDING_GITHUB_TOKENS_KEY, pendingGitHubTokens)
 
-      res.send(
+      res.reply(
         `You can authorize access at ${HOST}/github/auth/${token} in the next 5 minutes.`,
       )
     })


### PR DESCRIPTION
The github auth command was using `send`, which sends a message unthreaded. This isn't really what we're looking for, so authorizations are now done in-thread by using `reply`.