### PR TITLE
One Weekday At A Time: Add weekday support to reminders

### DIFF
--- a/lib/remind/data.ts
+++ b/lib/remind/data.ts
@@ -44,7 +44,7 @@ export type PersistedJob =
 export type SingleShotDefinition = {
   hour: number
   minute: number
-  dayOfWeek: number
+  dayOfWeek: number | number[]
 }
 
 export type RecurringDefinition =

--- a/lib/remind/formatting.ts
+++ b/lib/remind/formatting.ts
@@ -33,14 +33,17 @@ function formatRecurringSpec(
   const formattedNextOccurrence = formatNextOccurrence(nextOccurrence)
 
   if (spec.repeat === "week") {
-    const baseDate = dayjs()
-      .day(spec.dayOfWeek)
-      .hour(spec.hour)
-      .minute(spec.minute)
+    const baseDate = dayjs().hour(spec.hour).minute(spec.minute)
+    const daysOfWeek =
+      typeof spec.dayOfWeek === "number" ? [spec.dayOfWeek] : spec.dayOfWeek
+
+    const formattedDays = daysOfWeek
+      .map((day) => baseDate.day(day).format("dddd"))
+      .join(", ")
 
     return (
       formattedNextOccurrence +
-      baseDate.format("[ (recurs weekly on] dddd [at] HH:mm[)]")
+      baseDate.format(`[ (recurs weekly at] HH:mm [on ${formattedDays}])]`)
     )
   }
 

--- a/lib/remind/index.ts
+++ b/lib/remind/index.ts
@@ -51,15 +51,27 @@ export function computeNextRecurrence(
   } else if (repeat === "week") {
     const { interval, dayOfWeek } = normalizedSpec
 
+    const possibleDays = (
+      typeof dayOfWeek === "number" ? [dayOfWeek] : [...dayOfWeek]
+    ).sort()
+    const earliestMatchingDay =
+      possibleDays.find(
+        (day) =>
+          repeatDate.day() < day ||
+          (repeatDate.day() === day &&
+            (repeatDate.hour() < hour ||
+              (repeatDate.hour() === hour && repeatDate.minute() < minute))),
+      ) ?? possibleDays[0]
+
     if (
-      repeatDate.day() < dayOfWeek ||
-      (repeatDate.day() === dayOfWeek &&
+      repeatDate.day() < earliestMatchingDay ||
+      (repeatDate.day() === earliestMatchingDay &&
         (repeatDate.hour() < hour ||
           (repeatDate.hour() === hour && repeatDate.minute() < minute)))
     ) {
-      repeatDate = repeatDate.day(dayOfWeek)
+      repeatDate = repeatDate.day(earliestMatchingDay)
     } else {
-      repeatDate = repeatDate.add(interval, "week").day(dayOfWeek)
+      repeatDate = repeatDate.add(interval, "week").day(earliestMatchingDay)
     }
   }
 

--- a/lib/remind/index.ts
+++ b/lib/remind/index.ts
@@ -167,10 +167,7 @@ export default class JobScheduler {
 
     const job: Job = {
       ...partialJob,
-      next: computeNextRecurrence(
-        dayjs().subtract(1, "day").toISOString(),
-        partialJob.spec,
-      ),
+      next: computeNextRecurrence(dayjs().toISOString(), partialJob.spec),
     }
 
     return this.addJob(job)

--- a/lib/remind/parsing.ts
+++ b/lib/remind/parsing.ts
@@ -47,7 +47,7 @@ const specMatcher = new RegExp(
     "(?<relativeIntervalUnit>(?:minutes?|hours?|days?|weeks?)(?:\\W|$)+))?" +
     "(?<daySpec>" +
     `(?:${intervalMatcher.source})?` +
-    `(?:(?:of the month|(?:${weekDayMatcher.source})s?)(?:\\W|$)+)?)?` +
+    `(?:(?:of the month|weekday|(?:${weekDayMatcher.source})s?)(?:\\W|$)+)?)?` +
     "(?:at\\s+(?<timeSpec>[^\\s]+)(?:\\W|$))?|" +
     "\\s+(?:at\\s+(?<timeSpec2>[^\\s]+))?(?:\\W|$)",
 )
@@ -61,7 +61,10 @@ const startMatcher = /remind (?<who>me|team|here|room) (?:to )?(?<message>.*)$/s
  *
  * If the weekday couldn't be interpreted, it is interpreted as Sunday.
  */
-function normalizeDayOfWeek(dayOfWeek: string): 0 | 1 | 2 | 3 | 4 | 5 | 6 {
+function normalizeDayOfWeek(dayOfWeek: string): number | number[] {
+  if (dayOfWeek === "weekday") {
+    return [1, 2, 3, 4, 5]
+  }
   if (dayOfWeek.startsWith("M")) {
     return 1
   }
@@ -237,7 +240,11 @@ function parseRecurringSpec(
 ): RecurringDefinition {
   const interval = jobDaySpecifier?.match(intervalMatcher)?.[0].trim() ?? "1"
   const normalizedInterval = normalizeInterval(interval)
-  const dayOfWeek = weekDayMatcher.exec(jobDaySpecifier)
+  const trimmedDaySpecifier = jobDaySpecifier.trim().replace(/s$/, "")
+  const dayOfWeek =
+    trimmedDaySpecifier === "weekday"
+      ? [trimmedDaySpecifier]
+      : weekDayMatcher.exec(trimmedDaySpecifier)
 
   const daySpec =
     dayOfWeek === null

--- a/lib/remind/parsing.ts
+++ b/lib/remind/parsing.ts
@@ -359,11 +359,14 @@ export function parseFromString(envelope: Envelope): JobDefinition | null {
     userId: envelope.user.id,
     room: envelope.room,
   }
-  // Extract thread id if available.
+  // Extract thread id if available for non-recurring messages. Note that
+  // recurring messages are expected to start fresh threads on every
+  // recurrence.
   const envelopeMessage = envelope.message
   if (
     "metadata" in envelopeMessage &&
-    (envelopeMessage as MatrixMessage).metadata.threadId !== undefined
+    (envelopeMessage as MatrixMessage).metadata.threadId !== undefined &&
+    spec.type === "single"
   ) {
     messageInfo.threadId = (envelopeMessage as MatrixMessage).metadata.threadId
   }

--- a/lib/remind/parsing.ts
+++ b/lib/remind/parsing.ts
@@ -15,11 +15,11 @@ import {
 
 // Match a number specifier for "in <number> <unit>"-style text.
 const numericTextMatcher =
-  /(?:an?|one|two|three|four|five|six|seven|eight|nine|ten|[0-9]+)(?:\W|$)+/
+  /(?:an?|one|two|three|four|five|six|seven|eight|nine|ten|[0-9]+)(?:\s|$)+/
 
 // Match an interval specifier for "every <interval> <day>"-style text.
 const intervalMatcher =
-  /(?:other|seco|thi|four|fif|[0-9]{1,2})(?:th|rd|st|nd)?(?:\W|$)+/
+  /(?:other|seco|thi|four|fif|[0-9]{1,2})(?:th|rd|st|nd)?(?:\s|$)+/
 
 // Match weekdays, allowing for arbitrary abbreviation (e.g. M or Mo or Mon or
 // Monday).
@@ -44,12 +44,12 @@ const specMatcher = new RegExp(
   "\\s*(?<type>in|on|next|every)\\s+" +
     "(?:" +
     `(?<relativeIntervalCount>${numericTextMatcher.source})` +
-    "(?<relativeIntervalUnit>(?:minutes?|hours?|days?|weeks?)(?:\\W|$)+))?" +
+    "(?<relativeIntervalUnit>(?:minutes?|hours?|days?|weeks?)(?:\\s|$)+))?" +
     "(?<daySpec>" +
     `(?:${intervalMatcher.source})?` +
-    `(?:(?:of the month|weekday|(?:${weekDayMatcher.source})s?)(?:\\W|$)+)?)?` +
-    "(?:at\\s+(?<timeSpec>[^\\s]+)(?:\\W|$))?|" +
-    "\\s+(?:at\\s+(?<timeSpec2>[^\\s]+))?(?:\\W|$)",
+    `(?:(?:of the month|weekday|(?:${weekDayMatcher.source})s?)(?:\\s|$)+)?)?` +
+    "(?:at\\s+(?<timeSpec>[^\\s]+)(?:\\s|$))?|" +
+    "\\s+(?:at\\s+(?<timeSpec2>[^\\s]+))?(?:\\s|$)",
 )
 
 // Match text that contains a reminder command.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "hubot-diagnostics": "^1.0.0",
     "hubot-even-better-help": "git+https://github.com/thesis/hubot-even-better-help.git#3192eedf2a0f11dd0b5fa736e0b9033741a59050",
     "hubot-gif-locker": "^1.0.7",
-    "hubot-matrix": "git+https://github.com/thesis/hubot-matrix.git#v3.0.0-beta.1",
+    "hubot-matrix": "git+https://github.com/thesis/hubot-matrix.git#v3.0.0-beta.3",
     "hubot-redis-brain": "^1.0.0",
     "hubot-rules": "^0.1.2",
     "hubot-scripts": "^2.17.2",

--- a/test/lib/remind/remind.spec.ts
+++ b/test/lib/remind/remind.spec.ts
@@ -326,6 +326,27 @@ describe("reminder spec parsing", () => {
     expect(expectedSpec).toEqual(parseSpec(str)?.jobSpec)
   })
 
+  test.each([
+    {
+      name: "in the middle",
+      str: "remind me every weekday at 16:33 to do things",
+      expectedSpec: {
+        ...weeklySpec,
+        spec: { ...weeklySpec.spec, dayOfWeek: [1, 2, 3, 4, 5] },
+      },
+    },
+    {
+      name: "at the end",
+      str: "remind me to do things every weekday at 16:33",
+      expectedSpec: {
+        ...weeklySpec,
+        spec: { ...weeklySpec.spec, dayOfWeek: [1, 2, 3, 4, 5] },
+      },
+    },
+  ])("supports weekly specs for weekdays $name", ({ str, expectedSpec }) => {
+    expect(expectedSpec).toEqual(parseSpec(str)?.jobSpec)
+  })
+
   const baseDate = "2022-12-02" // A Friday
   const baseTime = "16:33:00Z"
 

--- a/test/lib/remind/remind.spec.ts
+++ b/test/lib/remind/remind.spec.ts
@@ -94,6 +94,41 @@ describe("reminder scheduling", () => {
     },
   )
 
+  const weeklyMultiDayDefiniton = {
+    ...weeklyDefinition,
+    dayOfWeek: [1, 2, 3, 4, 5],
+  }
+
+  test.each([
+    {
+      name: "with previous recurrence before the first day",
+      previousRecurrenceISO: "2022-12-03T16:33:00Z",
+      expectedNextRecurrenceISO: "2022-12-05T16:33:00.000Z",
+    },
+    {
+      name: "with previous recurrence on a recurrence day one minute before",
+      previousRecurrenceISO: `${weeklyBaseDate}T16:32:00Z`,
+      expectedNextRecurrenceISO: `${weeklyBaseDate}T16:33:00.000Z`,
+    },
+    {
+      name: "with previous recurrence on a recurrence day one minute after",
+      previousRecurrenceISO: `${weeklyBaseDate}T16:34:00Z`,
+      expectedNextRecurrenceISO: "2022-12-07T16:33:00.000Z",
+    },
+    {
+      name: "with previous recurrence after the last day",
+      previousRecurrenceISO: "2022-12-10T16:33:00Z",
+      expectedNextRecurrenceISO: "2022-12-12T16:33:00.000Z",
+    },
+  ] as const)(
+    "supports weekly specs on multiple days $name",
+    ({ previousRecurrenceISO, expectedNextRecurrenceISO }) => {
+      expect(
+        computeNextRecurrence(previousRecurrenceISO, weeklyMultiDayDefiniton),
+      ).toEqual(expectedNextRecurrenceISO)
+    },
+  )
+
   const weeklyIntervalDefinition = {
     repeat: "week",
     dayOfWeek: 2,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2884,9 +2884,9 @@ hubot-gif-locker@^1.0.7:
   dependencies:
     coffee-script "~1.6"
 
-"hubot-matrix@git+https://github.com/thesis/hubot-matrix.git#v3.0.0-beta.1":
-  version "3.0.0-beta.1"
-  resolved "git+https://github.com/thesis/hubot-matrix.git#f5c43ab8377d98557b48ac01e3b93402b19e2897"
+"hubot-matrix@git+https://github.com/thesis/hubot-matrix.git#v3.0.0-beta.3":
+  version "3.0.0-beta.3"
+  resolved "git+https://github.com/thesis/hubot-matrix.git#f55ee8d732c2ad0ed2f366466a695f71caf433b4"
   dependencies:
     commonmark "^0.30.0"
     image-size "^0.5.1"


### PR DESCRIPTION
Using the command `\remind me every weekday at <x> to ...` (or `to ... every weekday at <x>`) now works!

Other tidbits here:
- Bumped to latest hubot-matrix to pull in better room names in reminder lists, as well as to render softbreaks as hard breaks in Markdown.
- Initial recurrences for remind jobs are computed as of the moment the job was created. It was being handled as of one day prior, to deal with certain issues in `computeNextRecurrence`. These were fixed in previous work.
- Recurring reminders always post their own threads, instead of posting in the thread they were scheduled. Single-shot reminders still post in the originating thread.

Note that it is (a) still not timezone aware (#140) and (b) not holiday-aware.