### PR TITLE
Zoning Laws: Add timezone support to Valkyrie and `remind` command

### DIFF
--- a/scripts/remind.ts
+++ b/scripts/remind.ts
@@ -1,22 +1,22 @@
 // Description:
 //   Create a reminder message
 //
-//   Lightly based on hubot-schedule by matsukaz <matsukaz@gmail.com>
-//
-// Dependencies:
-//   "lodash"        : "^4.17.14",
-//   "chrono-node"   : "^1.3.11",
-//
 // Commands:
-//   hubot remind [me|team|here] <day or date in English> <message> - Create a reminder, in the current flow, that runs at a specific date and time, using regular English syntax to describe the date/time. See https://www.npmjs.com/package/chrono-node for examples of accepted date formats. Note: you CAN include a timezone in your request, but all times will be Displayed in UTC.
-//   hubot reminder [cancel|del|delete|remove] <id> - Cancel the reminder for the specified id.
-//   hubot reminder [upd|update] <id> <message> - Update the message for the reminder with the specified id.
-//   hubot reminder list - List all reminders for the current flow or DM. NOTE all times are displayed in UTC.
-//   hubot reminder list <flow> - List all reminders for the specified flow. NOTE all times are displayed in UTC.
-//   hubot reminder list all - List all reminders for any public flows (reminders in DMs or invite-only flows are hidden from this list, except when called from a DM or private flow). NOTE all times are displayed in UTC.
+//   hubot remind [me|team|here|room] on `when` `message`, or `message` on `when` - Post a reminder message at a specific date and time (e.g. `March 13th at 1:45pm` or `Tuesday at 15:13`), in the current thread. NOTE all times are interpreted as being in your timezone per the timezone command.
+//   hubot remind [me|team|here|room] in `when` `message`, or `message` in `when` - Post a reminder message at a relative time in the future (e.g. `in 5 days` or `in three hours` or `in 5 minutes`), in the current thread. NOTE all times are interpreted as being in your timezone per the timezone command.
+//   hubot remind [me|team|here|room] every `when` `message`, or `message` every `when` - Post a message in the current room, as a new thread, every set amount of time (e.g. `every 5 days` or `every Monday at 1:45pm` or `every 3rd of the month at 15:13`). NOTE all times are interpreted as being in your timezone per the timezone command.
+//   hubot remind [me|team|here|room] every weekday at `time` `message`, or `message` every weekday at `time` - Post a message in the current room, as a new thread, every weekday (Monday through Friday). Does not skip holidays. NOTE all times are interpreted as being in your timezone per the timezone command.
+//   hubot remind(ers) [cancel|del|delete|remove] `id` - Cancel the reminder for the specified id.
+//   hubot reminder(ers) [upd|update] `id` to say `message` - Update the message for the reminder with the specified id.
+//   hubot reminder(ers) [upd|update] `id` to every `when` - Update the repetition of the reminder with the specified id, e.g. `to every 5 days` or `to every Monday at 1:35pm` or `to every 3rd of the month at 15:13`. NOTE all times are interpreted as being in your timezone per the timezone command.
+//   hubot reminder(ers) [upd|update] `id` to every weekday at `time` - Update the repetition of the reminder with the specified id to be every weekday at the specified time. NOTE all times are interpreted as being in your timezone per the timezone command.
+//   hubot reminder(ers) list - List all reminders for the current room or DM. NOTE all times are displayed in your timezone per the timezone command.
+//   hubot reminder(ers) list `room` - List all reminders for the specified room. NOTE all times are displayed in your timezone per the timezone command.
+//   hubot reminder(ers) list all - List all reminders for any public rooms (reminders in DMs or invite-only rooms are hidden from this list, except when called from a DM or private room). NOTE all times are displayed in your timezone per the timezone command.
 //
 // Author:
 //   kb0rg
+//   shadowfiend
 //
 
 import { Robot } from "hubot"

--- a/scripts/user-preferences.ts
+++ b/scripts/user-preferences.ts
@@ -1,0 +1,125 @@
+// Description:
+//   A collection of utilities to manage user preferences.
+//
+// Commands:
+//   hubot timezone <timezone specifier> - Sets the timezone for you, used in places like reminders.
+//   hubot timezone - Tells you the timezone being used for your user.
+//
+// Author:
+//   shadowfiend
+//
+
+import { Robot } from "hubot"
+import * as dayjs from "dayjs"
+import * as utc from "dayjs/plugin/utc"
+import * as timezone from "dayjs/plugin/timezone"
+import * as advancedFormat from "dayjs/plugin/advancedFormat"
+
+dayjs.extend(utc)
+dayjs.extend(timezone)
+dayjs.extend(advancedFormat)
+dayjs.tz.setDefault("UTC")
+
+const USER_PREFERENCES_BRAIN_KEY = "preferences"
+
+export type UserPreferences = {
+  timezone: string
+}
+
+// Eastern time in particular must be stated as EST5EDT to properly handle
+// daylight savings time automatically (other timezones like CET, Pacific, etc,
+// do this by default). Additionally, we want to support commonly-used aliases
+// like "Pacific", "Eastern", etc which are not directly supported by dayjs.
+const TIMEZONE_MAPS: { [alias: string]: string } = {
+  Eastern: "EST5EDT",
+  EST: "EST5EDT",
+  EDT: "EST5EDT",
+  Pacific: "PST8PDT",
+  Central: "CST6CDT", // Time, Standard Time, Daylight Time
+  Mountain: "America/Phoenix", // Time, Standard Time
+  "Mountain Daylight Time": "America/Boise",
+}
+
+module.exports = (robot: Robot<any>) => {
+  robot.respond(/timezone$/i, (msg) => {
+    const userPreferences = robot.brain.get(USER_PREFERENCES_BRAIN_KEY)?.[
+      msg.envelope.user.id
+    ] as UserPreferences
+
+    if ((userPreferences?.timezone ?? undefined) !== undefined) {
+      msg.reply(`I have you in ${userPreferences.timezone}.`)
+    } else {
+      msg.reply(
+        `I don't know your timezone, so I'm assuming ${dayjs().format(
+          "zzz (z)",
+        )}.`,
+      )
+    }
+  })
+
+  robot.respond(/timezone\s+(.*)/i, (msg) => {
+    const userPreferences = robot.brain.get(USER_PREFERENCES_BRAIN_KEY)?.[
+      msg.envelope.user.id
+    ] as UserPreferences
+
+    const existingTimezone = userPreferences?.timezone ?? dayjs().format("zzz")
+
+    const trimmedUserTimezone = msg.match[1].trim()
+    const adjustedTimezone =
+      // Try to find a replacement in the maps
+      TIMEZONE_MAPS[trimmedUserTimezone] ??
+      // If not, try finding a replacement for just the first word if in the
+      // format X Time, X Standard Time, or X Daylight Time.
+      TIMEZONE_MAPS[
+        trimmedUserTimezone.replace(/(Daylight|Standard)? Time/, "").trim()
+      ] ??
+      // If not, just use the provided value directly.
+      msg.match[1]
+
+    try {
+      dayjs.tz("2023-08-19T17:15", adjustedTimezone)
+
+      robot.brain.set(USER_PREFERENCES_BRAIN_KEY, {
+        ...robot.brain.get(USER_PREFERENCES_BRAIN_KEY),
+        [msg.envelope.user.id]: {
+          ...userPreferences,
+          timezone: adjustedTimezone,
+        },
+      })
+
+      msg.reply(
+        `Updated your timezone from ${existingTimezone} to ${adjustedTimezone}.`,
+      )
+    } catch (error) {
+      msg.reply(
+        `Couldn't properly understand ${msg.match[1]} as a timezone. Try ` +
+          "going to https://greenwichmeantime.com/time-zone/ and using the " +
+          "time zone listed as your local one halfway down the page (e.g. " +
+          "`America/New_York`).",
+      )
+    }
+  })
+}
+
+/**
+ * Exported function to look up user preferences on a given robot for a given
+ * user id.
+ */
+module.exports.userPreferencesFor = function userPreferencesFor(
+  robot: Robot<any>,
+  userId: string,
+) {
+  return robot.brain.get(USER_PREFERENCES_BRAIN_KEY)?.[
+    userId
+  ] as UserPreferences
+}
+
+module.exports.userTimezoneFor = function timezoneFor(
+  robot: Robot<any>,
+  userId: string,
+) {
+  return (
+    module.exports.userPreferencesFor(robot, userId)?.timezone ??
+    dayjs().format("Z")
+  )
+}


### PR DESCRIPTION
A few things here:
- Help aliasing is back, which allows e.g. `remind help` to be the same as `help remind`. This got nuked during the TypeScript port, more accidentally than anything else.
- A new `timezone` command that shows you the timezone Valkyrie is considering to be yours.
- A new `timezone <timezone>` command that lets you set that timezone to something specific. Some aliases are supported here (e.g. `Eastern` for EST5EDT, which auto-adjusts to DST), though that list may need to be expanded.
- An update to `remind` that takes your timezone into account when processing times (and, where relevant, dates).

Notably in the process of building this out, it became clear that `dayjs` is buggy when dealing with timezones, particularly when dealing with a non-UTC system timezone. This means tests haven't been fully updated here as they behave poorly on my local machine. The right long-term move is going to be to move to [luxon](https://moment.github.io/luxon/), which has timezones at its heart instead of as a plugin. That's going to require shaving some yaks.