### PR TITLE
Fill in some missing timezone handling in formatting

### DIFF
--- a/lib/remind/formatting.ts
+++ b/lib/remind/formatting.ts
@@ -49,11 +49,13 @@ function formatRecurringSpec(
     )
   }
 
-  const baseDate = DateTime.now().set({
-    day: spec.dayOfMonth,
-    hour: spec.hour,
-    minute: spec.minute,
-  })
+  const baseDate = DateTime.now()
+    .set({
+      day: spec.dayOfMonth,
+      hour: spec.hour,
+      minute: spec.minute,
+    })
+    .setZone(timezone)
 
   return (
     formattedNextOccurrence +
@@ -92,6 +94,9 @@ export function formatJobForMessage(
   return `ID ${job.id}: **${formattedSpec}** ${targetDisplayText}:\n>${messageParsed}\n\n`
 }
 
-export function formatJobsForListMessage(jobs: PersistedJob[]) {
-  return jobs.map((job) => formatJobForMessage(job)).join("\n\n")
+export function formatJobsForListMessage(
+  jobs: PersistedJob[],
+  timezone?: string,
+) {
+  return jobs.map((job) => formatJobForMessage(job, timezone)).join("\n\n")
 }


### PR DESCRIPTION
When formatting monthly reminders, the user's timezone wasn't being taken into account. Similarly, when formatting the reminder list, the timezone wasn't being passed through correctly for the individual reminders, so weekly reminders likewise did not take the user's timezone into account.