### PR TITLE
Zonal Contrast: Fix next occurrence timezone in recurring jobs, load existing reminders correctly

### DIFF
--- a/lib/remind/formatting.ts
+++ b/lib/remind/formatting.ts
@@ -26,7 +26,7 @@ function formatRecurringSpec(
   nextOccurrence: string,
   timezone?: string,
 ): string {
-  const formattedNextOccurrence = formatNextOccurrence(nextOccurrence)
+  const formattedNextOccurrence = formatNextOccurrence(nextOccurrence, timezone)
 
   if (spec.repeat === "week") {
     const baseDate = DateTime.now()

--- a/lib/remind/index.ts
+++ b/lib/remind/index.ts
@@ -96,9 +96,10 @@ export default class JobScheduler {
 
   constructor(
     private robot: Hubot.Robot,
-    initialJobs: PersistedJob[],
     private persistenceKey: string = "jobs",
   ) {
+    const initialJobs = robot.brain.get(persistenceKey) as PersistedJob[]
+
     this.maxId = initialJobs.reduce(
       (runningMax, { id }) => Math.max(runningMax, id),
       0,

--- a/scripts/remind.ts
+++ b/scripts/remind.ts
@@ -35,14 +35,9 @@ import {
 
 import { isBlank } from "../lib/schedule-util"
 
-const REMINDER_KEY = "hubot_reminders"
-
 module.exports = function setupRemind(robot: Robot) {
   robot.brain.once("loaded", () => {
-    const jobScheduler = new JobScheduler(
-      robot,
-      robot.brain.get(REMINDER_KEY) ?? [],
-    )
+    const jobScheduler = new JobScheduler(robot)
 
     robot.respond(/remind (me|team|here) ((?:.|\s)*)$/i, (msg) => {
       const timezone = userTimezoneFor(robot, msg.envelope.user.id)

--- a/test/lib/remind/remind.spec.ts
+++ b/test/lib/remind/remind.spec.ts
@@ -443,7 +443,7 @@ describe("reminder spec parsing", () => {
   ])("supports relative specs $name", ({ str, expectedSpec }) => {
     jest.useFakeTimers({ now: new Date(`${baseDate}T${baseTime}`) })
 
-    expect(expectedSpec).toEqual(parseSpec(str, "UTC")?.jobSpec)
+    expect(expectedSpec).toEqual(parseSpec(str, "utc")?.jobSpec)
   })
 
   const baseSingleTimeSpec = {
@@ -457,7 +457,7 @@ describe("reminder spec parsing", () => {
       str: "remind me in 6 days at 13:12 to do things",
       expectedSpec: {
         ...baseSingleTimeSpec,
-        spec: { ...baseSingleTimeSpec.spec, dayOfWeek: 12 },
+        spec: { ...baseSingleTimeSpec.spec, dayOfWeek: 11 },
       },
     },
     {
@@ -465,7 +465,7 @@ describe("reminder spec parsing", () => {
       str: "remind me to do things in 6 days at 13:12",
       expectedSpec: {
         ...baseSingleTimeSpec,
-        spec: { ...baseSingleTimeSpec.spec, dayOfWeek: 12 },
+        spec: { ...baseSingleTimeSpec.spec, dayOfWeek: 11 },
       },
     },
     {
@@ -501,8 +501,8 @@ describe("reminder spec parsing", () => {
       },
     },
   ])("supports relative specs with time $name", ({ str, expectedSpec }) => {
-    // jest.useFakeTimers({ now: new Date(`${baseDate}T${baseTime}`) })
+    jest.useFakeTimers({ now: new Date(`${baseDate}T${baseTime}`) })
 
-    expect(parseSpec(str, "UTC")?.jobSpec).toEqual(expectedSpec)
+    expect(parseSpec(str, "utc")?.jobSpec).toEqual(expectedSpec)
   })
 })


### PR DESCRIPTION
The two commit messages outline the details, but short version:
- The formatted reminders for recurring jobs now correctly display the next occurrence in the user's chosen timezone (if they have chosen one).
- The scheduler is now in charge of both reading and writing jobs to the robot brain. This fixes an issue where the scheduler was receiving a list from a brain key that was not the same as the one it was writing new and updated jobs to.