### PR TITLE
Remind Rooms: remind respond matcher accepts `room` as a target

### DIFF
--- a/scripts/remind.ts
+++ b/scripts/remind.ts
@@ -39,7 +39,7 @@ module.exports = function setupRemind(robot: Robot) {
   robot.brain.once("loaded", () => {
     const jobScheduler = new JobScheduler(robot)
 
-    robot.respond(/remind (me|team|here) ((?:.|\s)*)$/i, (msg) => {
+    robot.respond(/remind (me|team|here|room) ((?:.|\s)*)$/i, (msg) => {
       const timezone = userTimezoneFor(robot, msg.envelope.user.id)
 
       try {


### PR DESCRIPTION
This was being accepted by the parser, but had been left out of the respond pattern, preventing the bot from actually handing it off to the remind parser and scheduler.