### PR TITLE
Avoid /usr/bin/env issue on Linux in Dockerfile

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -5,4 +5,4 @@ set -e
 yarn install
 export PATH="node_modules/.bin:node_modules/hubot/node_modules/.bin:$PATH"
 
-exec node_modules/.bin/hubot --alias "\\" --name "valkyrie" "$@"
+exec node node_modules/.bin/hubot --alias "\\" --name "valkyrie" "$@"

--- a/infrastructure/docker/Dockerfile
+++ b/infrastructure/docker/Dockerfile
@@ -53,4 +53,6 @@ WORKDIR /hubot
 
 ENV PATH="node_modules/.bin:node_modules/hubot/node_modules/.bin:$PATH"
 
+ENV NODE_OPTIONS="--experimental-vm-modules --experimental-loader ts-node/esm"
+
 ENTRYPOINT ["bin/hubot", "--name", "valkyrie", "--adapter", "matrix"]


### PR DESCRIPTION
To do this, bin/hubot now invokes node directly instead of relying on the shebang in node_modules/.bin/hubot, which is currently broken. Additionally, we set the NODE_OPTIONS to enable the experimental features needed for ESM loading and TypeScript transpilation at load time.