### PR TITLE
The TSening part the last: Finalize NODE_OPTIONS handling with hubot dep bump

### DIFF
--- a/bin/heimdall
+++ b/bin/heimdall
@@ -12,4 +12,4 @@ if test -f matrix-password.gpg; then
 	export HUBOT_MATRIX_PASSWORD=`gpg -q -d matrix-password.gpg`
 fi
 
-exec node_modules/.bin/hubot --alias "?" --name "heimdall" "$@"
+NODE_OPTIONS="--experimental-vm-modules --experimental-loader ts-node/esm" exec node_modules/.bin/hubot --alias "?" --name "heimdall" "$@"

--- a/bin/hubot
+++ b/bin/hubot
@@ -4,4 +4,5 @@ set -e
 
 export PATH="node_modules/.bin:node_modules/hubot/node_modules/.bin:$PATH"
 
-exec node node_modules/.bin/hubot --alias "\\" --name "valkyrie" "$@"
+
+NODE_OPTIONS="--experimental-vm-modules --experimental-loader ts-node/esm" exec node_modules/.bin/hubot --alias "\\" --name "valkyrie" "$@"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "cronstrue": "^1.68.0",
     "decode-html": "^2.0.0",
     "github-api": "^3.4.0",
-    "hubot": "git+https://github.com/thesis/hubot.git#v4.0.0-alpha.0",
+    "hubot": "git+https://github.com/thesis/hubot.git#v4.0.0-alpha.1",
     "hubot-diagnostics": "^1.0.0",
     "hubot-even-better-help": "git+https://github.com/thesis/hubot-even-better-help.git#3192eedf2a0f11dd0b5fa736e0b9033741a59050",
     "hubot-gif-locker": "^1.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3121,9 +3121,9 @@ hubot-test-helper@^1.9.0:
     optparse "1.0.4"
     scoped-http-client "0.11.0"
 
-"hubot@git+https://github.com/thesis/hubot.git#v4.0.0-alpha.0":
-  version "4.0.0-alpha.0"
-  resolved "git+https://github.com/thesis/hubot.git#bbec713568c5fcc54b9a2f554717d0dfb37a9585"
+"hubot@git+https://github.com/thesis/hubot.git#v4.0.0-alpha.1":
+  version "4.0.0-alpha.1"
+  resolved "git+https://github.com/thesis/hubot.git#9d6b86717634c7efec3dfc050b735cfc2ca7a319"
   dependencies:
     async ">=0.1.0 <1.0.0"
     chalk "^1.0.0"


### PR DESCRIPTION
The hubot bin file is now set up to have a proper shebang, and requires NODE_OPTIONS to be defined externally. These are now done on `bin/heimdall` and `bin/hubot`.