### PR TITLE
Dissident Scripts: Add thread management and compact embeds scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 .vscode/*
 
 matrix-password.gpg
+discord-token.gpg

--- a/discord-scripts/compact-embeds.ts
+++ b/discord-scripts/compact-embeds.ts
@@ -1,0 +1,40 @@
+import { PartialMessage, Client, Message, EmbedBuilder } from "discord.js"
+
+async function compactGithubEmbeds(message: Message<boolean> | PartialMessage) {
+  if (message.author === null || message.author === undefined) {
+    return
+  }
+
+  if (!message.author.bot) {
+    const receivedEmbeds = message.embeds
+    if (
+      !receivedEmbeds ||
+      !receivedEmbeds.find((embed) => embed.url && embed.url.includes("github"))
+    ) {
+      return
+    }
+
+    await message.suppressEmbeds(true)
+    const description = receivedEmbeds
+      .map((embed, i) => `(${i + 1}) [${embed.title}](${embed.url})`)
+      .join("\n")
+    const embed = new EmbedBuilder()
+      .setColor("#0099ff")
+      .setDescription(description)
+
+    message.channel.send({ embeds: [embed] })
+  }
+}
+
+// Suppresses default GitHub embeds in all Discord messages, replacing them
+// with an extremely shortened version that only shows the page title with a
+// link.
+export default function compactGitHubEmbeds(discordClient: Client) {
+  discordClient.on("messageCreate", (message) => {
+    compactGithubEmbeds(message)
+  })
+
+  discordClient.on("messageUpdate", (message) => {
+    compactGithubEmbeds(message)
+  })
+}

--- a/discord-scripts/thread-management.ts
+++ b/discord-scripts/thread-management.ts
@@ -1,0 +1,134 @@
+import { Channel, ChannelType, Client } from "discord.js"
+
+// Emoji used to suggest a thread.
+const THREAD_EMOJI = "🧵"
+// Category that is treated as recreational, i.e. the rules don't apply baby.
+const RECREATIONAL_CATEGORY_ID = "1079492118692757605"
+
+function isInRecreationalCategory(
+  channel: Channel | undefined | null,
+): boolean {
+  if (
+    channel === undefined ||
+    channel === null ||
+    channel.isDMBased() ||
+    channel.parent === null
+  ) {
+    return false
+  }
+
+  // Channel is inside a category.
+  if (channel.parent.type === ChannelType.GuildCategory) {
+    return channel.parent.id === RECREATIONAL_CATEGORY_ID
+  }
+
+  // Channel's parent is inside a category; this applies to thread channels.
+  if (channel.parent.parent !== null) {
+    return channel.parent.id === RECREATIONAL_CATEGORY_ID
+  }
+
+  return false
+}
+
+export default function manageThreads(discordClient: Client) {
+  // When a thread is created, join it.
+  //
+  // Additionally, quietly tag a role so that all members of it are subscribed
+  // to the thread (they may later leave the thread to opt out). The role that
+  // is tagged is, in order:
+  //
+  // - If the containing channel's category is recreational, no role.
+  // - If the containnig channel has a role with a matching name, that role
+  //   (e.g., a message to #tech will tag a Tech role if it exists).
+  // - If the containing channel's category has a role with a matching name, that role
+  //   (e.g., a message to #taho-standup inside the Taho category will tag the
+  //   Taho role if it exists).
+  // - If the containing channel's category is General and the channel is
+  //   #main, @everyone.
+  discordClient.on("threadCreate", async (thread) => {
+    await thread.join()
+
+    if (isInRecreationalCategory(thread)) {
+      return
+    }
+
+    const { guild: server, parent: containingChannel } = thread
+
+    const placeholder = await thread.send("<placeholder>")
+
+    const matchingRole = server.roles.cache.find(
+      (role) =>
+        role.name.toLowerCase() === containingChannel?.name.toLowerCase(),
+    )
+
+    if (matchingRole !== undefined) {
+      await placeholder.edit(matchingRole.toString())
+      return
+    }
+
+    const categoryChannel = containingChannel?.parent
+    const categoryMatchingRole = server.roles.cache.find(
+      (role) => role.name.toLowerCase() === categoryChannel?.name.toLowerCase(),
+    )
+
+    if (categoryMatchingRole !== undefined) {
+      await placeholder.edit(categoryMatchingRole.toString())
+      return
+    }
+
+    if (
+      categoryChannel?.name?.toLowerCase()?.endsWith("general") === true &&
+      containingChannel?.name?.toLowerCase()?.endsWith("main") === true
+    ) {
+      await placeholder.edit(server.roles.everyone.toString())
+    }
+
+    if (
+      categoryChannel?.name?.toLowerCase()?.endsWith("general") === true &&
+      containingChannel?.name?.toLowerCase()?.endsWith("bifrost") === true
+    ) {
+      await placeholder.edit(server.roles.everyone.toString())
+    }
+
+    // Monstrous, delete the useless placeholder and pray for our soul.
+    // Placeholder code as we figure out the best way to handle the General
+    // category.
+    await placeholder.delete()
+  })
+
+  // Remind users to create a thread with a reacji for reply chains longer than
+  // 1 reply. Skip for messages in the recreational category.
+  discordClient.on("messageCreate", async (message) => {
+    // If we're already in a thread or this is the recreational category, do
+    // nothing.
+    const { channel } = message
+    if (channel.isThread() || isInRecreationalCategory(channel)) {
+      return
+    }
+
+    // If this message is not in reply to anything, do nothing.
+    if (
+      message.reference === null ||
+      message.reference.messageId === undefined
+    ) {
+      return
+    }
+
+    // If the message replied to is not in reply to anythinbg, still do nothing.
+    const repliedMessage = await message.fetchReference()
+    if (
+      repliedMessage.reference === null ||
+      repliedMessage.reference.messageId === undefined
+    ) {
+      return
+    }
+
+    // Okay, now we've got a chain of two replies, suggest a thread via reacji
+    // on the original message---if it is indeed the original message in the
+    // chain.
+    const potentialOriginalMessage = await repliedMessage.fetchReference()
+    if (potentialOriginalMessage.reference === null) {
+      message.react(THREAD_EMOJI)
+    }
+  })
+}


### PR DESCRIPTION
Borrowed extensively from http://github.com/thesis/bishop, h/t @beaushinkle .

The thread management scripts are modified from their original form; in particular, rather than always mentioning the same role to ensure thread visibility, a heuristic is used:

- If the thread's channel has a role with the same name, that role is used.
- If not, but the thread's channel's category has a role with the same name, that role is used.
- If neither of these is true and the post is in #main in the General category, @-everyone is used.

Notably, Bishop's management of thread lifecycle, specifically around keeping threads alive for 7 days always, as well as pinging a thread to see if it should be archived periodically, are not yet included.

Also, the file organization is very different here compared to Bishop, keeping related functionality in a single file instead of spreading out over many files. This is intentional.