### PR TITLE
Old embeds: Fix issue with double GitHub embeds

### DIFF
--- a/discord-scripts/compact-embeds.ts
+++ b/discord-scripts/compact-embeds.ts
@@ -34,7 +34,7 @@ export default function compactGitHubEmbeds(discordClient: Client) {
     compactGithubEmbeds(message)
   })
 
-  discordClient.on("messageUpdate", (message) => {
-    compactGithubEmbeds(message)
+  discordClient.on("messageUpdate", (_, newMessage) => {
+    compactGithubEmbeds(newMessage)
   })
 }

--- a/infrastructure/docker/Dockerfile
+++ b/infrastructure/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN apk add --no-cache \
 
 COPY yarn.lock package.json ./
 
-RUN yarn install
+RUN yarn install --frozen-lockfile
 
 RUN mkdir web bin discord-scripts scripts lib test
 COPY external-scripts.json .


### PR DESCRIPTION
Compacted GitHub embeds were being added twice due to the messageUpdated hook referencing the old message instead of the newly edited message when processing an edit.