### PR TITLE
Easy Embeds It: Less aggressive embed replacement for GitHub links

### DIFF
--- a/discord-scripts/compact-embeds.ts
+++ b/discord-scripts/compact-embeds.ts
@@ -9,7 +9,9 @@ async function compactGithubEmbeds(message: Message<boolean> | PartialMessage) {
     const receivedEmbeds = message.embeds
     if (
       !receivedEmbeds ||
-      !receivedEmbeds.find((embed) => embed.url && embed.url.includes("github.com"))
+      !receivedEmbeds.find(
+        (embed) => embed.url && embed.url.includes("github.com"),
+      )
     ) {
       return
     }

--- a/discord-scripts/compact-embeds.ts
+++ b/discord-scripts/compact-embeds.ts
@@ -9,7 +9,7 @@ async function compactGithubEmbeds(message: Message<boolean> | PartialMessage) {
     const receivedEmbeds = message.embeds
     if (
       !receivedEmbeds ||
-      !receivedEmbeds.find((embed) => embed.url && embed.url.includes("github"))
+      !receivedEmbeds.find((embed) => embed.url && embed.url.includes("github.com"))
     ) {
       return
     }

--- a/scripts/current-build.ts
+++ b/scripts/current-build.ts
@@ -28,7 +28,7 @@ try {
 }
 const buildNumber = buildNumberBuffer.toString().trim()
 const buildString = buildNumber
-  ? `build [${buildNumber}](https://github.com/thesis/valkyrie/commit/${buildNumber})`
+  ? `build ${buildNumber} from https://github.com/thesis/valkyrie/commit/${buildNumber}`
   : "unknown build"
 
 function sendReleaseNotification(robot: Robot) {


### PR DESCRIPTION
We were replacing embeds if the URL included GitHub, this was also eliminating cases where GitHub user content links were embedding images or videos. Replacement now only happens if the URL includes github.com specifically.