### PR TITLE
Async real talk: Properly log async Discord script loading errors, and other things

### DIFF
--- a/discord-scripts/figma-integration.ts
+++ b/discord-scripts/figma-integration.ts
@@ -216,7 +216,7 @@ export default async function figmaIntegration(
   discordClient: Client,
   robot: DiscordHubot,
 ) {
-  robot.logger.info("Configuring up Figma integration.")
+  robot.logger.info("Configuring Figma integration.")
 
   const { application } = discordClient
   if (application === null) {

--- a/scripts/current-build.ts
+++ b/scripts/current-build.ts
@@ -34,7 +34,7 @@ const buildString = buildNumber
 function sendReleaseNotification(robot: Robot) {
   const alertRoom = process.env.RELEASE_NOTIFICATION_ROOM
   if (alertRoom !== undefined) {
-    robot.messageRoom(alertRoom, `Released ${buildString}!`)
+    robot.messageRoom(alertRoom, `Released ${buildString} !`)
   }
 }
 

--- a/scripts/discord.ts
+++ b/scripts/discord.ts
@@ -7,7 +7,10 @@ import path from "path"
 // A script with a default export that takes a Discord client and returns
 // nothing.
 type DiscordScript = {
-  default: (client: Client, robot: Hubot.Robot<DiscordBot>) => void
+  default: (
+    client: Client,
+    robot: Hubot.Robot<DiscordBot>,
+  ) => void | Promise<void>
 }
 
 function attachWithAdapter(robot: Hubot.Robot) {
@@ -23,11 +26,18 @@ function attachWithAdapter(robot: Hubot.Robot) {
             const discordScript: DiscordScript = await import(
               path.join("..", "discord-scripts", file)
             )
-            discordScript.default(client, robot as Hubot.Robot<DiscordBot>)
+            await discordScript.default(
+              client,
+              robot as Hubot.Robot<DiscordBot>,
+            )
             robot.logger.info(`Loaded Discord script ${file}.`)
           } catch (error) {
             robot.logger.error(
-              `Failed to load Discord script ${file}: ${error}`,
+              `Failed to load Discord script ${file}: ${JSON.stringify(
+                error,
+                null,
+                2,
+              )}`,
             )
           }
         })


### PR DESCRIPTION
This addresses the failure to log Figma integration boot up errors.

Release messages also get some fixes, and we're finally going to try to get some clarity on why deployment comments don't work!