### PR TITLE
Validate body req of webhook and make tagUser optional

### DIFF
--- a/scripts/admin.ts
+++ b/scripts/admin.ts
@@ -44,11 +44,9 @@ const SUPER_ADMIN_USERS = ["@matt:thesis.co", "@shadowfiend:thesis.co"]
 
 const ADMIN_USERS = [
   ...SUPER_ADMIN_USERS,
-  "@puppycodes:thesis.co",
   "@carolyn:thesis.co",
   "@gluzman:thesis.co",
   "@jessiefrance:thesis.co",
-  "@veronica:thesis.co",
 ]
 
 // Additional per-space admins beyond the core Thesis admins.
@@ -60,17 +58,10 @@ const SPACE_ADMINS: { [spaceRoomId: string]: string[] } = {
   // Keep space.
   "!YDpOcIsEpQabwiHpdV:thesis.co": ["@piotr.dyraga:thesis.co"],
   // Tally Ho space.
-  "!wCfAwzfZOUHTYIDjRn:thesis.co": [
-    "@michaelh:thesis.co",
-    "@puppycodes:thesis.co",
-  ],
+  "!wCfAwzfZOUHTYIDjRn:thesis.co": ["@michaelh:thesis.co"],
   // Fold space.
-  "!SuBAnawNxcIXoCHfPM:thesis.co": [
-    "@tom:thesis.co",
-    "@willreeves:thesis.co",
-    "@puppycodes:thesis.co",
-  ],
-  // Power Period space.
+  "!SuBAnawNxcIXoCHfPM:thesis.co": ["@tom:thesis.co", "@willreeves:thesis.co"],
+  // Embody space.
   "!XEnwlDoWvSBvrloDVH:thesis.co": ["@anna:thesis.co"],
 }
 


### PR DESCRIPTION
This PR adds a simple validation on the request body of discord's webhook and makes `tagUser` param optional. I've made it default to `"0"` because I'm assuming n8n sends `"0"` since there's a check for that, but if that's not the case we could change this just to check if the value is a string, to not blow up while calling `.split` which I've also changed the placement, bc `memberIds` was not used anywhere else, so it makes more sense to move it.

Also it updates the admin list.

Not sure why tests are failing, seems a port issue, maybe it's the worker ?