### PR TITLE
Fix twitter embeds: Use fxtwitter.com to fix embeds for Twitter links

### DIFF
--- a/discord-scripts/compact-embeds.ts
+++ b/discord-scripts/compact-embeds.ts
@@ -1,6 +1,8 @@
 import { PartialMessage, Client, Message, EmbedBuilder } from "discord.js"
 
-async function compactGithubEmbeds(message: Message<boolean> | PartialMessage) {
+async function generateCompactGitHubEmbeds(
+  message: Message<boolean> | PartialMessage,
+) {
   if (message.author === null || message.author === undefined) {
     return
   }
@@ -33,10 +35,10 @@ async function compactGithubEmbeds(message: Message<boolean> | PartialMessage) {
 // link.
 export default function compactGitHubEmbeds(discordClient: Client) {
   discordClient.on("messageCreate", (message) => {
-    compactGithubEmbeds(message)
+    generateCompactGitHubEmbeds(message)
   })
 
   discordClient.on("messageUpdate", (_, newMessage) => {
-    compactGithubEmbeds(newMessage)
+    generateCompactGitHubEmbeds(newMessage)
   })
 }

--- a/discord-scripts/fix-twitter-embed.ts
+++ b/discord-scripts/fix-twitter-embed.ts
@@ -1,0 +1,59 @@
+import { PartialMessage, Client, Message, EmbedBuilder } from "discord.js"
+
+async function workingTwitterEmbeds(
+  message: Message<boolean> | PartialMessage,
+) {
+  if (message.author === null || message.author === undefined) {
+    return
+  }
+
+  if (!message.author.bot) {
+    const content = message.content ?? ""
+    if (content.match(/(https:\/\/(x|twitter).com\/[a-zA-Z0-9%/+]+)/)) {
+      const allLinks = Array.from(
+        content.matchAll(/(https:\/\/(x|twitter).com\/[a-zA-Z0-9%/+]+)/g),
+      )
+        .map(([twitterLink]) =>
+          twitterLink.replace(/https:\/\/(x|twitter)/, "https://fxtwitter"),
+        )
+        .join(" , ")
+
+      await message.channel.send(allLinks)
+    }
+
+    const receivedEmbeds = message.embeds
+    if (
+      !receivedEmbeds ||
+      !receivedEmbeds.find(
+        (embed) => embed.url && embed.url.includes("github.com"),
+      )
+    ) {
+      return
+    }
+
+    await message.suppressEmbeds(true)
+    const description = receivedEmbeds
+      .map((embed, i) => `(${i + 1}) [${embed.title}](${embed.url})`)
+      .join("\n")
+    const embed = new EmbedBuilder()
+      .setColor("#0099ff")
+      .setDescription(description)
+
+    message.channel.send({ embeds: [embed] })
+  }
+}
+
+// Follows up any message with 1+ Twitter links (including x.com) with a
+// message that includes fxtwitter links, which correctly embed into Discord,
+// expand t.co links, and have a couple of other nice features.
+//
+// See https://github.com/FixTweet/FxTwitter for more.
+export default function fixTwitterEmbeds(discordClient: Client) {
+  discordClient.on("messageCreate", (message) => {
+    workingTwitterEmbeds(message)
+  })
+
+  discordClient.on("messageUpdate", (_, newMessage) => {
+    workingTwitterEmbeds(newMessage)
+  })
+}

--- a/discord-scripts/thread-management.ts
+++ b/discord-scripts/thread-management.ts
@@ -95,20 +95,6 @@ export default function manageThreads(discordClient: Client) {
       return
     }
 
-    if (
-      categoryChannel?.name?.toLowerCase()?.endsWith("general") === true &&
-      containingChannel?.name?.toLowerCase()?.endsWith("main") === true
-    ) {
-      await placeholder.edit(server.roles.everyone.toString())
-    }
-
-    if (
-      categoryChannel?.name?.toLowerCase()?.endsWith("general") === true &&
-      containingChannel?.name?.toLowerCase()?.endsWith("bifrost") === true
-    ) {
-      await placeholder.edit(server.roles.everyone.toString())
-    }
-
     // Monstrous, delete the useless placeholder and pray for our soul.
     // Placeholder code as we figure out the best way to handle the General
     // category.


### PR DESCRIPTION
Includes a couple of small stylistic fixes.

The main commit:

> When a new twitter.com/x.com link is seen, Valkyrie auto-replies with
> the same link switched to fxtwitter.com (see
> https://github.com/FixTweet/FxTwitter for the implementation). This
> produces an actual Discord embed, as well as auto-expanding t.co links
> and doing a couple of other useful things.
>
> Those who wish to can also change the link to always redirect to nitter
> instead of twitter (e.g. if you do not stay logged in or if twitter is
> broken for you).