### PR TITLE
Locked Channels: Mark all private channels with a prefix 🔒

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -132,6 +132,21 @@ jobs:
     secrets:
       GCP_DEPLOY_CREDENTIALS: ${{ secrets.GCP_DEPLOY_CREDENTIALS }}
 
+  # Deploy depends on a freshly built image. Force deploy instead runs when
+  # someone requests a deploy from a comment, and bypasses tests and builds (as
+  # these are expected to have run previously).
+  force-deploy:
+    needs: [decide-parameters]
+    if: ${{ needs.decide-parameters.outputs.should-deploy == 'true' && needs.decide-parameters.outputs.should-build == 'false' }}
+    uses: ./.github/workflows/deploy.yml
+    with:
+      docker-image-name: valkyrie
+      docker-image-version: ${{ github.sha }}
+      gcp-project-name: thesis-ops
+      gcp-project-id: thesis-ops-2748
+    secrets:
+      GCP_DEPLOY_CREDENTIALS: ${{ secrets.GCP_DEPLOY_CREDENTIALS }}
+
   lint:
     needs: [decide-parameters]
     if: ${{ needs.decide-parameters.outputs.should-build == 'true' }}

--- a/discord-scripts/figma-integration.ts
+++ b/discord-scripts/figma-integration.ts
@@ -10,11 +10,9 @@ import {
 import { randomBytes } from "crypto"
 
 import * as Figma from "figma-api"
-import { DiscordBot } from "hubot-discord"
 import { User } from "figma-api/lib/api-types"
 import { HOST, MINUTE } from "../lib/globals.ts"
-
-type DiscordHubot = Hubot.Robot<DiscordBot>
+import { DiscordHubot } from "../lib/discord/utils.ts"
 
 const COMMAND_NAME = "figma"
 const CONNECT_SUBCOMMAND_NAME = "connect"

--- a/discord-scripts/privacy-tagging.ts
+++ b/discord-scripts/privacy-tagging.ts
@@ -1,0 +1,23 @@
+import { Channel, Client } from "discord.js"
+import { isPrivate } from "../lib/discord/utils.ts"
+
+async function ensurePrivacyEmoji(channel: Channel) {
+  if (channel.isDMBased()) {
+    return
+  }
+
+  if (isPrivate(channel)) {
+    if (!channel.name.startsWith("🔒")) {
+      await channel.setName(`🔒 ${channel.name.replace(/^ +/, "")}`)
+    }
+  }
+}
+
+// Ensures private channels and threads are always prefixed by the lock emoji
+// (🔒) for clear visibility in the sidebar.
+export default function privacyTagging(discordClient: Client) {
+  discordClient.on("threadCreate", ensurePrivacyEmoji)
+  discordClient.on("threadUpdate", ensurePrivacyEmoji)
+  discordClient.on("channelCreate", ensurePrivacyEmoji)
+  discordClient.on("channelUpdate", ensurePrivacyEmoji)
+}

--- a/discord-scripts/thread-management.ts
+++ b/discord-scripts/thread-management.ts
@@ -1,34 +1,8 @@
-import { Channel, ChannelType, Client } from "discord.js"
+import { ChannelType, Client } from "discord.js"
+import { isInRecreationalCategory } from "../lib/discord/utils.ts"
 
 // Emoji used to suggest a thread.
 const THREAD_EMOJI = "🧵"
-// Category that is treated as recreational, i.e. the rules don't apply baby.
-const RECREATIONAL_CATEGORY_ID = "1079492118692757605"
-
-function isInRecreationalCategory(
-  channel: Channel | undefined | null,
-): boolean {
-  if (
-    channel === undefined ||
-    channel === null ||
-    channel.isDMBased() ||
-    channel.parent === null
-  ) {
-    return false
-  }
-
-  // Channel is inside a category.
-  if (channel.parent.type === ChannelType.GuildCategory) {
-    return channel.parent.id === RECREATIONAL_CATEGORY_ID
-  }
-
-  // Channel's parent is inside a category; this applies to thread channels.
-  if (channel.parent.parent !== null) {
-    return channel.parent.id === RECREATIONAL_CATEGORY_ID
-  }
-
-  return false
-}
 
 export default function manageThreads(discordClient: Client) {
   // When a thread is created, join it.

--- a/discord-scripts/thread-management.ts
+++ b/discord-scripts/thread-management.ts
@@ -28,23 +28,20 @@ export default function manageThreads(discordClient: Client) {
 
     const { guild: server, parent: containingChannel } = thread
 
-    if (thread.type === ChannelType.GuildPrivateThread) {
-      if (!thread.name.startsWith("🔒")) {
-        await thread.setName(`🔒 ${thread.name.replace(/^ +/, "")}`)
-      }
-
-      if (containingChannel?.name?.toLowerCase() !== "operations") {
-        await thread.send(
-          "Private threads should largely only be used for discussions around " +
-            "confidential topics like legal and hiring. They should as a result " +
-            "almost always be created in #operations; if you know you're " +
-            "breaking both rules on purpose, go forth and conquer, but otherwise " +
-            "please start the thread there. I'm also going to auto-tag the " +
-            "appropriate roles now, which may compromise the privacy of the " +
-            "thread (**all members of the role who have access to this channel " +
-            "will have access to the thread**).",
-        )
-      }
+    if (
+      thread.type === ChannelType.PrivateThread &&
+      containingChannel?.name?.toLowerCase() !== "operations"
+    ) {
+      await thread.send(
+        "Private threads should largely only be used for discussions around " +
+          "confidential topics like legal and hiring. They should as a result " +
+          "almost always be created in #operations; if you know you're " +
+          "breaking both rules on purpose, go forth and conquer, but otherwise " +
+          "please start the thread there. I'm also going to auto-tag the " +
+          "appropriate roles now, which may compromise the privacy of the " +
+          "thread (**all members of the role who have access to this channel " +
+          "will have access to the thread**).",
+      )
     }
 
     const placeholder = await thread.send("<placeholder>")

--- a/lib/discord/utils.ts
+++ b/lib/discord/utils.ts
@@ -1,0 +1,91 @@
+import { Channel, ChannelType, AnyThreadChannel } from "discord.js"
+import { DiscordBot } from "hubot-discord"
+
+export type DiscordHubot = Hubot.Robot<DiscordBot>
+
+// Category that is treated as recreational, i.e. the rules don't apply baby.
+export const RECREATIONAL_CATEGORY_ID = "1079492118692757605"
+
+/**
+ * Checks if a given channel is within the category considered "recreational".
+ * The recreational category contains channels that less formal and aren't
+ * subject to the usual rules meant to drive content organization and
+ * decision-making.
+ */
+export function isInRecreationalCategory(
+  channel: Channel | undefined | null,
+): boolean {
+  if (
+    channel === undefined ||
+    channel === null ||
+    channel.isDMBased() ||
+    channel.parent === null
+  ) {
+    return false
+  }
+
+  // Channel is inside a category.
+  if (channel.parent.type === ChannelType.GuildCategory) {
+    return channel.parent.id === RECREATIONAL_CATEGORY_ID
+  }
+
+  // Channel's parent is inside a category; this applies to thread channels.
+  if (channel.parent.parent !== null) {
+    return channel.parent.id === RECREATIONAL_CATEGORY_ID
+  }
+
+  return false
+}
+
+/**
+ * Checks if a given channel is private. This works across threads, categories,
+ * and voice and text channels. It does _not_ report DM channels as private, as
+ * it is designed for use on servers rather than in DMs.
+ */
+export function isPrivate(channel: Channel | undefined | null): boolean {
+  if (
+    channel === undefined ||
+    channel === null ||
+    channel.isDMBased() ||
+    channel.parent === null
+  ) {
+    return false
+  }
+
+  // Private and public threads get clear channel types.
+  if (channel.type === ChannelType.PrivateThread) {
+    return true
+  }
+
+  if (
+    channel.type === ChannelType.PublicThread ||
+    channel.type === ChannelType.AnnouncementThread
+  ) {
+    return false
+  }
+
+  // This cast is needed because the PublicThread/AnnouncementThread
+  // conditional above doesn't correctly filter out
+  // PublicThreadChannel<boolean> from the type list, even though it does
+  // practically exclude them.
+  const knownNonThreadChannel = channel as Exclude<
+    typeof channel,
+    AnyThreadChannel
+  >
+
+  // For other channels, heck if the base role has an override to prevent it
+  // from viewing the channel.
+  //
+  // NOTE: The way the Thesis Discord is set up, the base role does NOT have
+  // view access; however, channels that are private have an explicit DENY for
+  // the view permission. This is what we check for here, considering a channel
+  // private ONLY IF it explicitly denies view channel access.
+  const everyoneCanView =
+    knownNonThreadChannel.permissionOverwrites.cache
+      .get(channel.guild.roles.everyone.id)
+      ?.allow.has("ViewChannel") ?? true
+
+  return !everyoneCanView
+}
+
+export default function booyan() {}


### PR DESCRIPTION
This generalizes existing behavior for private threads to all channels.