### PR TITLE
Focus mode 

### DIFF
--- a/discord-scripts/focus-mode.ts
+++ b/discord-scripts/focus-mode.ts
@@ -1,0 +1,66 @@
+import {
+  ChannelType,
+  Client,
+  ButtonStyle,
+  ButtonBuilder,
+  ActionRowBuilder,
+  TextChannel,
+} from "discord.js"
+import { Robot } from "hubot"
+
+export default async function setupFocusChannels(
+  discordClient: Client,
+  robot: Robot,
+) {
+  discordClient.on("ready", async () => {
+    discordClient.guilds.cache.forEach(async (guild) => {
+      const focusChannel = guild.channels.cache.find(
+        (channel) =>
+          channel.type === ChannelType.GuildText &&
+          channel.name.startsWith("focus"),
+      ) as TextChannel | undefined
+
+      if (!focusChannel) {
+        robot.logger.info(`Focus channel not found in guild: ${guild.name}`)
+        return
+      }
+
+      const actionRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId("enable-focus")
+          .setLabel("Enable Focus")
+          .setStyle(ButtonStyle.Success),
+        new ButtonBuilder()
+          .setCustomId("disable-focus")
+          .setLabel("Disable Focus")
+          .setStyle(ButtonStyle.Danger),
+      )
+
+      await focusChannel.send({
+        content:
+          "**Focus Mode**\nSelect an option to enable or disable focus mode.",
+        components: [actionRow],
+      })
+
+      robot.logger.info(
+        `Focus mode options sent to the focus channel in guild: ${guild.name}`,
+      )
+    })
+  })
+
+  discordClient.on("interactionCreate", async (interaction) => {
+    if (interaction.isButton()) {
+      if (interaction.customId === "enable-focus") {
+        await interaction.reply({
+          content: "Focus mode enabled.",
+          ephemeral: true,
+        })
+      } else if (interaction.customId === "disable-focus") {
+        await interaction.reply({
+          content: "Focus mode disabled.",
+          ephemeral: true,
+        })
+      }
+    }
+  })
+}


### PR DESCRIPTION
### Notes
This adds a `focus-mode` controller to Valkyrie which allows discord users to set their roles to `focus`, which will temporarily hide specific discord channels until the focus mode is disabled

### Screenshots
<img width="626" alt="Screenshot 2024-02-08 at 12 26 54" src="https://github.com/thesis/valkyrie/assets/7145746/82eb2d60-3885-4a49-941b-a36f845ec119">


### To-do

- [ ] setup initial `focus-mode.ts` controller that spawns message event in channel
- [ ] Setup role management to change roles based on button events
- [ ] Set .env to specify channel IDs for non-thesis discord servers.
- [ ] tweak user flow accordingly. 