### PR TITLE
Defense channels and rolemapping

### DIFF
--- a/discord-scripts/invite-management.ts
+++ b/discord-scripts/invite-management.ts
@@ -221,8 +221,8 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
       )
 
       const usedInvite = fetchedInvites.find((fetchedInvite) => {
-        const oldUseCount = oldInvites.get(fetchedInvite.code)?.uses ?? 0
-        return (fetchedInvite.uses ?? 0) > oldUseCount
+        const oldInvite = oldInvites.get(fetchedInvite.code)
+        return (fetchedInvite.uses ?? 0) > (oldInvite ? oldInvite.uses : 0)
       })
 
       robot.logger.info(`Used Invite: ${usedInvite ? usedInvite.code : "None"}`)
@@ -238,18 +238,23 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
               ? "External"
               : "Internal"
             : null
-          const clientName = channelTypeMatch ? channelTypeMatch[2] : ""
-          robot.logger.info(`Channel Name: ${channelTypeMatch}`)
+          const clientName = channelTypeMatch
+            ? channelTypeMatch[2].replace(/-/g, " ")
+            : ""
+          robot.logger.info(`Channel Name: ${channel.name}`)
           robot.logger.info(`Audit Channel Type: ${auditChannelType}`)
 
           if (auditChannelType) {
-            const roleName = `Defense ${auditChannelType}: ${clientName}`
+            const fixedClientName = clientName
+              .split(" ")
+              .map(
+                (word) =>
+                  word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
+              )
+              .join(" ")
+            const roleName = `Defense ${auditChannelType}: ${fixedClientName}`
             const role = member.guild.roles.cache.find(
-              (r) =>
-                r.name
-                  .toLowerCase()
-                  .includes(`defense ${auditChannelType}`.toLowerCase()) &&
-                r.name.toLowerCase().includes(clientName.toLowerCase()),
+              (r) => r.name.toLowerCase() === roleName.toLowerCase(),
             )
 
             if (role) {

--- a/discord-scripts/invite-management.ts
+++ b/discord-scripts/invite-management.ts
@@ -164,9 +164,12 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
             })
 
             if (auditChannelType === "Internal") {
+              const normalizedClientName = clientName
+                .replace(/\s+/g, "-")
+                .toLowerCase()
               const externalAuditChannel = channel.guild.channels.cache.find(
                 (c) =>
-                  c.name === `🔒ext-${clientName.toLowerCase()}-audit` &&
+                  c.name === `🔒ext-${normalizedClientName}-audit` &&
                   c.parent &&
                   c.parent.name === "defense",
               ) as TextChannel

--- a/discord-scripts/invite-management.ts
+++ b/discord-scripts/invite-management.ts
@@ -275,10 +275,10 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
             await interaction.editReply({
               content:
                 `**Defense audit channels already set up for: ${clientName.value}**\n\n` +
-                `These channels were found here:\n` +
+                "These channels were found here:\n" +
                 `- Internal Channel: <#${internalChannel.id}> (Invite: \`${internalInvite.url}\`)\n` +
                 `- External Channel: <#${externalChannel.id}> (Invite: \`${externalInvite.url}\`)\n\n` +
-                `We've updated permissions to these roles:\n` +
+                "We've updated permissions to these roles:\n" +
                 `- Internal Role: <@&${internalRole.id}>\n` +
                 `- External Role: <@&${externalRole.id}>`,
             })

--- a/discord-scripts/invite-management.ts
+++ b/discord-scripts/invite-management.ts
@@ -26,14 +26,24 @@ async function createInvite(
 
 async function listInvites(discordClient: Client, robot: Robot): Promise<void> {
   discordClient.guilds.cache.forEach(async (guild) => {
-    const fetchInvites = await guild.invites.fetch().catch(error => {
-      robot.logger.error(`Failed to fetch invites for guild ${guild.name}: ${error}`)
+    const fetchInvites = await guild.invites.fetch().catch((error) => {
+      robot.logger.error(
+        `Failed to fetch invites for guild ${guild.name}: ${error}`,
+      )
     })
 
     if (fetchInvites) {
-      guildInvites.set(guild.id, new Collection(fetchInvites.map(invite => [invite.code, invite.uses])))
+      guildInvites.set(
+        guild.id,
+        new Collection(
+          fetchInvites.map((invite) => [invite.code, invite.uses]),
+        ),
+      )
       // just for debugging
-      robot.logger.info(`List all guild invites for ${guild.name}:`, guildInvites.get(guild.id))
+      robot.logger.info(
+        `List all guild invites for ${guild.name}:`,
+        guildInvites.get(guild.id),
+      )
     }
   })
 }
@@ -241,26 +251,25 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
         ) as TextChannel
         if (channel) {
           const channelTypeMatch = channel.name.match(/(ext|int)-(.*)-audit/)
-          const auditChannelType = channelTypeMatch
-            ? channelTypeMatch[1] === "ext"
-              ? "External"
-              : "Internal"
-            : null
           const clientName = channelTypeMatch
-            ? channelTypeMatch[2].replace(/-/g, " ")
+            ? channelTypeMatch[2]
+                .replace(/-/g, " ")
+                .split(" ")
+                .map(
+                  (word) =>
+                    word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
+                )
+                .join(" ")
             : ""
-          robot.logger.info(`Channel Name: ${channel.name}`)
-          robot.logger.info(`Audit Channel Type: ${auditChannelType}`)
 
-          if (auditChannelType) {
-            const fixedClientName = clientName
-              .split(" ")
-              .map(
-                (word) =>
-                  word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
-              )
-              .join(" ")
-            const roleName = `Defense ${auditChannelType}: ${fixedClientName}`
+          robot.logger.info(`Channel Name: ${channel.name}`)
+
+          if (channelTypeMatch) {
+            const auditType =
+              channelTypeMatch[1] === "ext" ? "External" : "Internal"
+            robot.logger.info(`Audit Channel Type: ${auditType}`)
+            const roleName = `Defense ${auditType}: ${clientName}`
+
             const role = member.guild.roles.cache.find(
               (r) => r.name.toLowerCase() === roleName.toLowerCase(),
             )

--- a/discord-scripts/invite-management.ts
+++ b/discord-scripts/invite-management.ts
@@ -242,11 +242,8 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
       }
     })
 
-    // WIP, just testing out invite counting in order to verify which invite was used on join
+    // Check list of invites and compare when a new user joins which invite code has been used, then assign role based on channel.name.match TO DO: Modify this to work with potentially all invites
     discordClient.on("guildMemberAdd", async (member: GuildMember) => {
-      // for debugging
-      robot.logger.info(member)
-
       const oldInvites =
         (guildInvites.get(member.guild.id) as Collection<
           string,

--- a/discord-scripts/invite-management.ts
+++ b/discord-scripts/invite-management.ts
@@ -1,9 +1,16 @@
 import { Robot } from "hubot"
-import { Client, Collection, TextChannel, GuildMember } from "discord.js"
+import {
+  ApplicationCommandOptionType,
+  Client,
+  ChannelType,
+  Collection,
+  TextChannel,
+  GuildMember,
+} from "discord.js"
 import { DAY, MILLISECOND, WEEK } from "../lib/globals.ts"
 
-const EXTERNAL_AUDIT_CHANNEL_REGEXP = /^ext-(?<client>.*)-audit$/
-const INTERNAL_AUDIT_CHANNEL_REGEXP = /^int-(?<client>.*)-audit$/
+// const EXTERNAL_AUDIT_CHANNEL_REGEXP = /^ext-(?<client>.*)-audit$/
+// const INTERNAL_AUDIT_CHANNEL_REGEXP = /^int-(?<client>.*)-audit$/
 const guildInvites = new Collection()
 
 async function createInvite(
@@ -69,6 +76,28 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
       })
       robot.logger.info("create invite command set")
     }
+
+    // Check if defense-audit command exists, if not create it
+    const existingDefenseCommand = (await application.commands.fetch()).find(
+      (command) => command.name === "defense-audit",
+    )
+    if (existingDefenseCommand === undefined) {
+      robot.logger.info("No defense-audit command found, creating it!")
+      await application.commands.create({
+        name: "defense-audit",
+        description: "Creates Defense audit channels",
+        options: [
+          {
+            name: "client-name",
+            type: ApplicationCommandOptionType.String,
+            description: "The name of the client to create the channels for",
+            required: true,
+          },
+        ],
+      })
+      robot.logger.info("Defense audit command set")
+    }
+
     // Create an invite based of the command and channel where the command has been run
     discordClient.on("interactionCreate", async (interaction) => {
       if (
@@ -106,114 +135,210 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
       }
     })
 
-    // Generates an invite if the channel name matches ext-*-audit format
-    discordClient.on("channelCreate", async (channel) => {
+    // Create the defense audit channels and roles based off the command
+    discordClient.on("interactionCreate", async (interaction) => {
       if (
-        channel.parent &&
-        channel.parent.name === "defense" &&
-        channel instanceof TextChannel &&
-        (EXTERNAL_AUDIT_CHANNEL_REGEXP.test(channel.name) ||
-          INTERNAL_AUDIT_CHANNEL_REGEXP.test(channel.name))
+        !interaction.isCommand() ||
+        interaction.commandName !== "defense-audit"
       ) {
-        const auditChannelType: string = EXTERNAL_AUDIT_CHANNEL_REGEXP.test(
-          channel.name,
-        )
-          ? "External"
-          : "Internal"
-        try {
-          const defenseInvite = await createInvite(channel)
-          if (defenseInvite) {
-            robot.logger.info(
-              `New invite created for defense ${auditChannelType.toLowerCase()} audit channel: ${
-                channel.name
-              }, URL: ${defenseInvite.url}`,
-            )
-            channel.send(
-              `Here is your invite link: ${
-                defenseInvite.url
-              }\nThis invite expires in ${
-                (defenseInvite.maxAge / DAY) * MILLISECOND
-              } days and has a maximum of ${defenseInvite.maxUses} uses.`,
-            )
-          }
-          // store new invites
-          await listInvites(discordClient, robot)
+        return
+      }
 
-          // Create a new role with the client name extracted and set permissions to that channel
-          const clientName = channel.name
-            .split("-")
-            .slice(1, -1)
-            .map(
-              (segment) =>
-                segment.substring(0, 1).toUpperCase() + segment.substring(1),
-            )
-            .join(" ")
+      if (!interaction.guild) {
+        await interaction.reply({
+          content: "This command can only be used in a server.",
+          ephemeral: true,
+        })
+        return
+      }
 
-          if (clientName) {
-            const roleName = `Defense ${auditChannelType}: ${
-              clientName || channel.name
-            }`
+      const clientName = interaction.options.get("client-name")
+      if (!clientName) {
+        await interaction.reply({
+          content: "Client name is required for the defense-audit command.",
+          ephemeral: true,
+        })
+        return
+      }
 
-            const role = await channel.guild.roles.create({
-              name: roleName,
-              reason: `Role for ${channel.name} channel`,
-            })
+      try {
+        if (typeof clientName.value === "string") {
+          const normalizedClientName = clientName.value
+            .replace(/\s+/g, "-")
+            .toLowerCase()
+          const internalChannelName = `int-${normalizedClientName}-audit`
+          const externalChannelName = `ext-${normalizedClientName}-audit`
 
-            await channel.permissionOverwrites.create(role, {
-              ViewChannel: true,
-            })
-
-            if (auditChannelType === "Internal") {
-              const normalizedClientName = clientName
-                .replace(/\s+/g, "-")
-                .toLowerCase()
-              const externalAuditChannel = channel.guild.channels.cache.find(
-                (c) =>
-                  c.name === `🔒ext-${normalizedClientName}-audit` &&
-                  c.parent &&
-                  c.parent.name === "defense",
-              ) as TextChannel
-
-              if (externalAuditChannel) {
-                await externalAuditChannel.permissionOverwrites.create(
-                  role.id,
-                  {
-                    ViewChannel: true,
-                  },
-                )
-                channel.send(
-                  `**${role.name}** role granted ViewChannel access to the external audit channel **${externalAuditChannel.name}**`,
-                )
-                robot.logger.info(
-                  `ViewChannel access granted to ${role.name} for external audit channel ${externalAuditChannel.name}`,
-                )
-              } else {
-                channel.send("No matching external audit channel found.")
-                robot.logger.info(
-                  "No matching external audit channel found for " +
-                    `ext-${clientName.toLowerCase()}-audit`,
-                )
-              }
-            }
-
-            channel.send(
-              `**${role.name}** role created and permissions set for **${channel.name}**`,
-            )
-            robot.logger.info(
-              `${role.name} role created and permissions set for channel ${channel.name}`,
-            )
-          } else {
-            robot.logger.info(
-              `Skipping role creation due to empty client name for channel ${channel.name}`,
-            )
-          }
-        } catch (error) {
-          robot.logger.error(
-            `An error occurred setting up the defense ${auditChannelType.toLowerCase()} audit channel: ${error}`,
+          const defenseCategory = interaction.guild.channels.cache.find(
+            (c) => c.name === "defense",
           )
+
+          if (!defenseCategory) {
+            await interaction.reply({
+              content: "Defense category does not exist.",
+              ephemeral: true,
+            })
+            return
+          }
+
+          const internalChannel = await interaction.guild.channels.create({
+            name: internalChannelName,
+            type: ChannelType.GuildText,
+            parent: defenseCategory.id,
+          })
+
+          const externalChannel = await interaction.guild.channels.create({
+            name: externalChannelName,
+            type: ChannelType.GuildText,
+            parent: defenseCategory.id,
+          })
+
+          const internalRoleName = `Defense Internal: ${clientName.value}`
+          const externalRoleName = `Defense External: ${clientName.value}`
+          const internalRole = await interaction.guild.roles.create({
+            name: internalRoleName,
+            reason: "Role for internal audit channel",
+          })
+          const externalRole = await interaction.guild.roles.create({
+            name: externalRoleName,
+            reason: "Role for external audit channel",
+          })
+
+          await internalChannel.permissionOverwrites.create(internalRole, {
+            ViewChannel: true,
+          })
+          await externalChannel.permissionOverwrites.create(externalRole, {
+            ViewChannel: true,
+          })
+          await externalChannel.permissionOverwrites.create(internalRole, {
+            ViewChannel: true,
+          })
+
+          const internalInvite = await createInvite(internalChannel)
+          const externalInvite = await createInvite(externalChannel)
+
+          await interaction.reply({
+            content: `Defense audit setup complete for: ${clientName}\n\nInternal Channel Invite: ${internalInvite.url}\nExternal Channel Invite: ${externalInvite.url}`,
+            ephemeral: true,
+          })
         }
+      } catch (error) {
+        robot.logger.error(error)
+        await interaction.reply({
+          content: "An error occurred while setting up the defense audit.",
+          ephemeral: true,
+        })
       }
     })
+
+    // // Generates an invite if the channel name matches ext-*-audit format
+    // discordClient.on("channelCreate", async (channel) => {
+    //   if (
+    //     channel.parent &&
+    //     channel.parent.name === "defense" &&
+    //     channel instanceof TextChannel &&
+    //     (EXTERNAL_AUDIT_CHANNEL_REGEXP.test(channel.name) ||
+    //       INTERNAL_AUDIT_CHANNEL_REGEXP.test(channel.name))
+    //   ) {
+    //     const auditChannelType: string = EXTERNAL_AUDIT_CHANNEL_REGEXP.test(
+    //       channel.name,
+    //     )
+    //       ? "External"
+    //       : "Internal"
+    //     try {
+    //       const defenseInvite = await createInvite(channel)
+    //       if (defenseInvite) {
+    //         robot.logger.info(
+    //           `New invite created for defense ${auditChannelType.toLowerCase()} audit channel: ${
+    //             channel.name
+    //           }, URL: ${defenseInvite.url}`,
+    //         )
+    //         channel.send(
+    //           `Here is your invite link: ${
+    //             defenseInvite.url
+    //           }\nThis invite expires in ${
+    //             (defenseInvite.maxAge / DAY) * MILLISECOND
+    //           } days and has a maximum of ${defenseInvite.maxUses} uses.`,
+    //         )
+    //       }
+    //       // store new invites
+    //       await listInvites(discordClient, robot)
+
+    //       // Create a new role with the client name extracted and set permissions to that channel
+    //       const clientName = channel.name
+    //         .split("-")
+    //         .slice(1, -1)
+    //         .map(
+    //           (segment) =>
+    //             segment.substring(0, 1).toUpperCase() + segment.substring(1),
+    //         )
+    //         .join(" ")
+
+    //       if (clientName) {
+    //         const roleName = `Defense ${auditChannelType}: ${
+    //           clientName || channel.name
+    //         }`
+
+    //         const role = await channel.guild.roles.create({
+    //           name: roleName,
+    //           reason: `Role for ${channel.name} channel`,
+    //         })
+
+    //         await channel.permissionOverwrites.create(role, {
+    //           ViewChannel: true,
+    //         })
+
+    //         if (auditChannelType === "Internal") {
+    //           const normalizedClientName = clientName
+    //             .replace(/\s+/g, "-")
+    //             .toLowerCase()
+    //           const externalAuditChannel = channel.guild.channels.cache.find(
+    //             (c) =>
+    //               c.name === `🔒ext-${normalizedClientName}-audit` &&
+    //               c.parent &&
+    //               c.parent.name === "defense",
+    //           ) as TextChannel
+
+    //           if (externalAuditChannel) {
+    //             await externalAuditChannel.permissionOverwrites.create(
+    //               role.id,
+    //               {
+    //                 ViewChannel: true,
+    //               },
+    //             )
+    //             channel.send(
+    //               `**${role.name}** role granted ViewChannel access to the external audit channel **${externalAuditChannel.name}**`,
+    //             )
+    //             robot.logger.info(
+    //               `ViewChannel access granted to ${role.name} for external audit channel ${externalAuditChannel.name}`,
+    //             )
+    //           } else {
+    //             channel.send("No matching external audit channel found.")
+    //             robot.logger.info(
+    //               "No matching external audit channel found for " +
+    //                 `ext-${clientName.toLowerCase()}-audit`,
+    //             )
+    //           }
+    //         }
+
+    //         channel.send(
+    //           `**${role.name}** role created and permissions set for **${channel.name}**`,
+    //         )
+    //         robot.logger.info(
+    //           `${role.name} role created and permissions set for channel ${channel.name}`,
+    //         )
+    //       } else {
+    //         robot.logger.info(
+    //           `Skipping role creation due to empty client name for channel ${channel.name}`,
+    //         )
+    //       }
+    //     } catch (error) {
+    //       robot.logger.error(
+    //         `An error occurred setting up the defense ${auditChannelType.toLowerCase()} audit channel: ${error}`,
+    //       )
+    //     }
+    //   }
+    // })
 
     // WIP, just testing out invite counting in order to verify which invite was used on join
     discordClient.on("guildMemberAdd", async (member: GuildMember) => {

--- a/discord-scripts/invite-management.ts
+++ b/discord-scripts/invite-management.ts
@@ -226,11 +226,8 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
           { uses: number }
         >) || new Collection<string, { uses: number }>()
       const fetchedInvites = await member.guild.invites.fetch()
-      const newInvites = new Collection<string, { uses: number }>(
-        fetchedInvites.map((invite) => [
-          invite.code,
-          { uses: invite.uses ?? 0 },
-        ]),
+      const newInvites = new Collection<string, number>(
+        fetchedInvites.map((invite) => [invite.code, invite.uses ?? 0]),
       )
       guildInvites.set(member.guild.id, newInvites)
 
@@ -243,7 +240,9 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
 
       const usedInvite = fetchedInvites.find((fetchedInvite) => {
         const oldInvite = oldInvites.get(fetchedInvite.code)
-        return (fetchedInvite.uses ?? 0) > (oldInvite ? oldInvite.uses : 0)
+        const oldUses =
+          typeof oldInvite === "object" ? oldInvite.uses : oldInvite
+        return (fetchedInvite.uses ?? 0) > (oldUses ?? 0)
       })
 
       robot.logger.info(`Used Invite: ${usedInvite ? usedInvite.code : "None"}`)

--- a/discord-scripts/invite-management.ts
+++ b/discord-scripts/invite-management.ts
@@ -71,7 +71,7 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
 
     // Check if defense-audit command exists, if not create it
     const existingDefenseCommand = (await application.commands.fetch()).find(
-      (command) => command.name === "defense-audit2",
+      (command) => command.name === "defense-audit",
     )
     if (existingDefenseCommand === undefined) {
       robot.logger.info("No defense-audit command found, creating it!")

--- a/discord-scripts/invite-management.ts
+++ b/discord-scripts/invite-management.ts
@@ -82,7 +82,7 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
         description: "Creates Defense audit channels",
         options: [
           {
-            name: "client-name",
+            name: "audit-name",
             type: ApplicationCommandOptionType.String,
             description:
               "The name of the audit/client to create the channels for.",
@@ -161,7 +161,7 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
         return
       }
 
-      const clientName = interaction.options.get("client-name")
+      const clientName = interaction.options.get("audit-name")
       if (!clientName) {
         await interaction.reply({
           content: "Client name is required for the defense-audit command.",

--- a/discord-scripts/invite-management.ts
+++ b/discord-scripts/invite-management.ts
@@ -9,8 +9,6 @@ import {
 } from "discord.js"
 import { DAY, MILLISECOND, WEEK } from "../lib/globals.ts"
 
-// const EXTERNAL_AUDIT_CHANNEL_REGEXP = /^ext-(?<client>.*)-audit$/
-// const INTERNAL_AUDIT_CHANNEL_REGEXP = /^int-(?<client>.*)-audit$/
 const guildInvites = new Collection()
 
 async function createInvite(
@@ -45,11 +43,6 @@ async function listInvites(discordClient: Client, robot: Robot): Promise<void> {
         new Collection(
           fetchInvites.map((invite) => [invite.code, invite.uses]),
         ),
-      )
-      // just for debugging
-      robot.logger.info(
-        `List all guild invites for ${guild.name}:`,
-        guildInvites.get(guild.id),
       )
     }
   })
@@ -264,13 +257,6 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
         fetchedInvites.map((invite) => [invite.code, invite.uses ?? 0]),
       )
       guildInvites.set(member.guild.id, newInvites)
-
-      robot.logger.info(
-        `Old Invites: ${JSON.stringify(Array.from(oldInvites.entries()))}`,
-      )
-      robot.logger.info(
-        `New Invites: ${JSON.stringify(Array.from(newInvites.entries()))}`,
-      )
 
       const usedInvite = fetchedInvites.find((fetchedInvite) => {
         const oldInvite = oldInvites.get(fetchedInvite.code)


### PR DESCRIPTION
### Notes
This adds a new discord command `defense-audit` which has one parameter `client-name` which will then perform the following steps:

- Create two channels, `int-clientname-audit` and `ext-clientname-audit` 
- Create two new roles `Defense Internal: clientname` and `Defense Extenal: clientname`
- Grant `ViewChannel` access to both channels for `Defense Internal: *` and only `ext-*-audit` channel access to `Defense Extenal`
- Generate an invite link for both channels

### Screenshot
<img width="702" alt="Screenshot 2024-03-20 at 13 51 15" src="https://github.com/thesis/valkyrie/assets/7145746/7abb64fd-3476-47db-96ec-55d2f8a88f42">


### Automatic role assignment
Also included in this PR is automatic role assignment based of the invite code used. Due to lack of IDs associated to `GuildMemberAdd` events when a new user joins discord, the only way to tie a discord user to an invite link is to count invite code uses within the guild and compare it once a new member has joined the discord. For this to work, we check the invites and match role assignment to channel.name the invite link was generated from. 

### To-do
- [x] Setup `defense-audit` command
- [x] Add rolemapping based on invite joins
- [x] Fix issue on `int-client-name-audit` channels not finding correct role for `ext-client-name-audit` channels
