### PR TITLE
Custom auto-tagging

### DIFF
--- a/discord-scripts/thread-management/auto-join.ts
+++ b/discord-scripts/thread-management/auto-join.ts
@@ -23,7 +23,7 @@ import {
 // it to mention the right role. Discord's behavior in this scenario is not to
 // ping the role, but to add all its members to the thread.
 
-const PRIVATE_CHANNELS = [{ channelName: "hiring", roleName: "PeopleOps" }]
+const CUSTOM_CHANNEL_ROLE = [{ channelName: "hiring", roleName: "PeopleOps" }]
 
 async function autoJoinThread(
   thread: AnyThreadChannel<boolean>,
@@ -37,6 +37,21 @@ async function autoJoinThread(
   const { guild: server, parent: containingChannel } = thread
 
   const placeholder = await thread.send("<placeholder>")
+
+  // Use this to assign a specific role based on the mapping in CUSTOM_CHANNEL_ROLE, in order to map specific roles/channels
+  const matchingChannel = CUSTOM_CHANNEL_ROLE.find(
+    (channel) => containingChannel?.name.endsWith(channel.channelName),
+  )
+  if (matchingChannel) {
+    const channelMatchingRole = server.roles.cache.find(
+      (role) =>
+        role.name.toLowerCase() === matchingChannel.roleName.toLowerCase(),
+    )
+    if (channelMatchingRole) {
+      await placeholder.edit(channelMatchingRole.toString())
+      return
+    }
+  }
 
   const matchingRole = server.roles.cache.find(
     (role) => role.name.toLowerCase() === containingChannel?.name.toLowerCase(),
@@ -72,21 +87,6 @@ async function autoJoinThread(
     // it does _not_ add everyone to the thread. Instead, it just sits there,
     // looking pretty.
     await placeholder.edit(server.roles.everyone.toString())
-  }
-
-  // Use this to assign a specific role based on the mapping in PRIVATE_CHANNELS, in order to map specific roles/channels
-  const matchingChannel = PRIVATE_CHANNELS.find(
-    (channel) => containingChannel?.name.endsWith(channel.channelName),
-  )
-  if (matchingChannel) {
-    const channelMatchingRole = server.roles.cache.find(
-      (role) =>
-        role.name.toLowerCase() === matchingChannel.roleName.toLowerCase(),
-    )
-    if (channelMatchingRole) {
-      await placeholder.edit(channelMatchingRole.toString())
-      return
-    }
   }
 
   // If we hit this spot, be a monster and delete the useless placeholder and

--- a/discord-scripts/thread-management/auto-join.ts
+++ b/discord-scripts/thread-management/auto-join.ts
@@ -22,6 +22,9 @@ import {
 // Quiet tags are achieved by dropping a placeholder message and then editing
 // it to mention the right role. Discord's behavior in this scenario is not to
 // ping the role, but to add all its members to the thread.
+
+const PRIVATE_CHANNELS = [{ channelName: "hiring", roleName: "PeopleOps" }]
+
 async function autoJoinThread(
   thread: AnyThreadChannel<boolean>,
 ): Promise<void> {
@@ -69,6 +72,21 @@ async function autoJoinThread(
     // it does _not_ add everyone to the thread. Instead, it just sits there,
     // looking pretty.
     await placeholder.edit(server.roles.everyone.toString())
+  }
+
+  // Use this to assign a specific role based on the mapping in PRIVATE_CHANNELS, in order to map specific roles/channels
+  const matchingChannel = PRIVATE_CHANNELS.find(
+    (channel) => containingChannel?.name.endsWith(channel.channelName),
+  )
+  if (matchingChannel) {
+    const channelMatchingRole = server.roles.cache.find(
+      (role) =>
+        role.name.toLowerCase() === matchingChannel.roleName.toLowerCase(),
+    )
+    if (channelMatchingRole) {
+      await placeholder.edit(channelMatchingRole.toString())
+      return
+    }
   }
 
   // If we hit this spot, be a monster and delete the useless placeholder and


### PR DESCRIPTION
### Notes
This adds the ability to modify the auto-tagging function of Valkyrie based off of a defined list of `PRIVATE_CHANNELS`. It also will match the tagging to the role specified, in order to have custom roles tagged for specific threads started in a channel.

### Handling IDs
Alternatively, we can also modify this to work directly with channel / role IDs rather than names, but in testing it seems to be working as it should.