### PR TITLE
Adjust auto-tagging

### DIFF
--- a/discord-scripts/thread-management/auto-join.ts
+++ b/discord-scripts/thread-management/auto-join.ts
@@ -23,7 +23,7 @@ import {
 // it to mention the right role. Discord's behavior in this scenario is not to
 // ping the role, but to add all its members to the thread.
 
-interface ChannelRoleMapping {
+type ChannelRoleMapping = {
   channelName?: string
   roleName?: string
 }

--- a/discord-scripts/thread-management/auto-join.ts
+++ b/discord-scripts/thread-management/auto-join.ts
@@ -23,7 +23,17 @@ import {
 // it to mention the right role. Discord's behavior in this scenario is not to
 // ping the role, but to add all its members to the thread.
 
-const CUSTOM_CHANNEL_ROLE = [{ channelName: "hiring", roleName: "PeopleOps" }]
+interface ChannelRoleMapping {
+  channelName?: string
+  roleName?: string
+}
+// For setting up custom channel tagging, follow the below format
+// const CUSTOM_CHANNEL_ROLE: ChannelRoleMapping[] = [{ channelName: "hiring", roleName: "PeopleOps" }]
+const CUSTOM_CHANNEL_ROLE: ChannelRoleMapping[] = [{}]
+
+const hasCustomChannels = CUSTOM_CHANNEL_ROLE.some(
+  (item) => item.channelName !== undefined && item.roleName !== undefined,
+)
 
 async function autoJoinThread(
   thread: AnyThreadChannel<boolean>,
@@ -39,17 +49,21 @@ async function autoJoinThread(
   const placeholder = await thread.send("<placeholder>")
 
   // Use this to assign a specific role based on the mapping in CUSTOM_CHANNEL_ROLE, in order to map specific roles/channels
-  const matchingChannel = CUSTOM_CHANNEL_ROLE.find(
-    (channel) => containingChannel?.name.endsWith(channel.channelName),
-  )
-  if (matchingChannel) {
-    const channelMatchingRole = server.roles.cache.find(
-      (role) =>
-        role.name.toLowerCase() === matchingChannel.roleName.toLowerCase(),
+
+  if (hasCustomChannels) {
+    const matchingChannel = CUSTOM_CHANNEL_ROLE.find(
+      (channel) => containingChannel?.name.endsWith(channel.channelName ?? ""),
     )
-    if (channelMatchingRole) {
-      await placeholder.edit(channelMatchingRole.toString())
-      return
+    if (matchingChannel) {
+      const channelMatchingRole = server.roles.cache.find(
+        (role) =>
+          role.name.toLowerCase() ===
+          (matchingChannel.roleName ?? "").toLowerCase(),
+      )
+      if (channelMatchingRole) {
+        await placeholder.edit(channelMatchingRole.toString())
+        return
+      }
     }
   }
 

--- a/discord-scripts/thread-management/auto-join.ts
+++ b/discord-scripts/thread-management/auto-join.ts
@@ -23,17 +23,11 @@ import {
 // it to mention the right role. Discord's behavior in this scenario is not to
 // ping the role, but to add all its members to the thread.
 
-type ChannelRoleMapping = {
-  channelName?: string
-  roleName?: string
+const CUSTOM_CHANNEL_ROLE: Record<string, string> = {
+  // hiring: "PeopleOps",
 }
-// For setting up custom channel tagging, follow the below format
-// const CUSTOM_CHANNEL_ROLE: ChannelRoleMapping[] = [{ channelName: "hiring", roleName: "PeopleOps" }]
-const CUSTOM_CHANNEL_ROLE: ChannelRoleMapping[] = [{}]
 
-const hasCustomChannels = CUSTOM_CHANNEL_ROLE.some(
-  (item) => item.channelName !== undefined && item.roleName !== undefined,
-)
+const hasCustomChannels = Object.keys(CUSTOM_CHANNEL_ROLE).length > 0
 
 async function autoJoinThread(
   thread: AnyThreadChannel<boolean>,
@@ -49,16 +43,11 @@ async function autoJoinThread(
   const placeholder = await thread.send("<placeholder>")
 
   // Use this to assign a specific role based on the mapping in CUSTOM_CHANNEL_ROLE, in order to map specific roles/channels
-
-  if (hasCustomChannels) {
-    const matchingChannel = CUSTOM_CHANNEL_ROLE.find(
-      (channel) => containingChannel?.name.endsWith(channel.channelName ?? ""),
-    )
-    if (matchingChannel) {
+  if (hasCustomChannels && containingChannel) {
+    const roleName = CUSTOM_CHANNEL_ROLE[containingChannel.name]
+    if (roleName) {
       const channelMatchingRole = server.roles.cache.find(
-        (role) =>
-          role.name.toLowerCase() ===
-          (matchingChannel.roleName ?? "").toLowerCase(),
+        (role) => role.name.toLowerCase() === roleName.toLowerCase(),
       )
       if (channelMatchingRole) {
         await placeholder.edit(channelMatchingRole.toString())


### PR DESCRIPTION
### Notes
This PR removes the custom channel auto-tagging for `#hiring` channel while also some refactoring in order to account for empty arrays better, since before it relied on at least one entry there at all times.