### PR TITLE
Advanced invite flow

### DIFF
--- a/discord-scripts/invite-management.ts
+++ b/discord-scripts/invite-management.ts
@@ -77,24 +77,6 @@ interface Invitation {
 
 const invitation: Invitation = {}
 
-async function createInvite(
-  channel: TextChannel,
-  maxAge = (1 * WEEK) / MILLISECOND,
-  maxUses = 10,
-): Promise<{ url: string; maxAge: number; maxUses: number }> {
-  const invite = await channel.createInvite({
-    maxAge,
-    maxUses,
-    unique: true,
-  })
-
-  return {
-    url: invite.url,
-    maxAge,
-    maxUses,
-  }
-}
-
 async function listInvites(discordClient: Client, robot: Robot): Promise<void> {
   discordClient.guilds.cache.forEach(async (guild) => {
     try {
@@ -112,6 +94,27 @@ async function listInvites(discordClient: Client, robot: Robot): Promise<void> {
       )
     }
   })
+}
+
+async function createInvite(
+  channel: TextChannel,
+  maxAge = (1 * WEEK) / MILLISECOND,
+  maxUses = 10,
+): Promise<{ url: string; maxAge: number; maxUses: number }> {
+  const invite = await channel.createInvite({
+    maxAge,
+    maxUses,
+    unique: true,
+  })
+
+  // Update list of invites after new invite is created
+  await listInvites
+
+  return {
+    url: invite.url,
+    maxAge,
+    maxUses,
+  }
 }
 
 export default async function sendInvite(discordClient: Client, robot: Robot) {
@@ -187,8 +190,6 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
             (1 * WEEK) / MILLISECOND,
             2,
           )
-          // Update list of invites after new invite is created
-          await listInvites(discordClient, robot)
           const internalInviteExpiry = Math.floor(
             Date.now() / 1000 + invite.maxAge,
           )
@@ -252,8 +253,6 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
             (1 * WEEK) / MILLISECOND,
             2,
           )
-          // Update list of invites after new invite is created
-          await listInvites(discordClient, robot)
           const internalInviteExpiry = Math.floor(
             Date.now() / 1000 + invite.maxAge,
           )
@@ -280,8 +279,6 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
       ) {
         try {
           const defenseInvite = await createInvite(channel)
-          // Update list of invites after new invite is created
-          await listInvites(discordClient, robot)
           if (defenseInvite) {
             robot.logger.info(
               `New invite created for defense audit channel: ${channel.name}, URL: ${defenseInvite.url}`,

--- a/discord-scripts/invite-management.ts
+++ b/discord-scripts/invite-management.ts
@@ -178,8 +178,12 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
       if (interaction.customId === "employee-no") {
         try {
           invitation.project = "Thesis Base"
+          const matchChannel = interaction.guild.channels.cache.find(
+            (c) => c.name === "🔒thesis-base",
+          ) as TextChannel
+          robot.logger.info(matchChannel)
           const invite = await createInvite(
-            channel,
+            matchChannel,
             (1 * WEEK) / MILLISECOND,
             2,
           )
@@ -393,14 +397,21 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
             const cleanChannelName = channel.name.replace(/🔒/g, "").trim()
             const rolesToAssign = cleanChannelName.split("-")
 
-            if (rolesToAssign.includes("thesis base")) {
+            if (rolesToAssign.includes("base")) {
               robot.logger.info("Thesis base role detected")
               const baseRole = member.guild.roles.cache.find(
-                (r) => r.name === "thesis-base",
+                (r) => r.name === "Thesis Base",
               )
               if (baseRole) {
                 await member.roles.add(baseRole)
               }
+              robot.logger.info(
+                `Invite code used: ${
+                  usedInvite ? usedInvite.code : "None"
+                }, Username joined: ${
+                  member.displayName
+                }, Role assignment: ${baseRole}`,
+              )
             }
 
             if (rolesToAssign.length >= 2) {

--- a/discord-scripts/invite-management.ts
+++ b/discord-scripts/invite-management.ts
@@ -414,7 +414,7 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
               )
             }
 
-            if (rolesToAssign.length >= 2) {
+            if (rolesToAssign.length >= 2 && !rolesToAssign.includes("base")) {
               const role1Name = rolesToAssign[0].trim()
               const role2Name = rolesToAssign[1].trim()
               const role1 = member.guild.roles.cache.find(

--- a/discord-scripts/invite-management.ts
+++ b/discord-scripts/invite-management.ts
@@ -319,6 +319,8 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
         return (fetchedInvite.uses ?? 0) > oldUses
       })
 
+      robot.logger.info(oldInvites)
+      robot.logger.info(newInvites)
       if (usedInvite && usedInvite.channelId) {
         const channel = member.guild.channels.cache.get(
           usedInvite.channelId,
@@ -358,7 +360,8 @@ export default async function sendInvite(discordClient: Client, robot: Robot) {
           }
 
           if (!auditChannelMatch) {
-            const rolesToAssign = channel.name.split("-")
+            const cleanChannelName = channel.name.replace(/🔒/g, "").trim()
+            const rolesToAssign = cleanChannelName.split("-")
 
             if (rolesToAssign.length >= 2) {
               const role1Name = rolesToAssign[0].trim()


### PR DESCRIPTION
### Notes
This adds a new feature to the `/create-invite` flow which prompts the inviter to select 3 main questions:
1. Is this a Thesis employee or contractor?
2. Which discipline(s) will this person be working with?
3. Which project(s) will this person be working with?

After those interactions are complete, an invite is generated with 7 days expiry and 2 uses (in-order to count invites on join) to the channel with `project-discipline` matching.

Still WIP

### Screenshots
<img width="598" alt="Screenshot 2024-04-24 at 16 36 53" src="https://github.com/thesis/valkyrie/assets/7145746/dfc27f16-0ca5-4917-9cc4-e06e20ff4ab0">

<img width="285" alt="Screenshot 2024-04-24 at 16 21 45" src="https://github.com/thesis/valkyrie/assets/7145746/eb9e92bb-8f38-48c8-a017-a084f4b3dfa0">


### To-do

- [x] Setup initial role / channel selection based off user input
- [x] Map invite join to necessary roles
- [x] Get contractor flow, channel selections.
- [x] Test across channel, edge cases