### PR TITLE
Update auto-join to try channel name prefixes

### DIFF
--- a/discord-scripts/thread-management/auto-join.ts
+++ b/discord-scripts/thread-management/auto-join.ts
@@ -66,7 +66,7 @@ async function autoJoinThread(
     .reduce(
       (allPrefixes, nameSegment) => [
         ...allPrefixes,
-        `${allPrefixes.at(-1) ?? []} ${nameSegment}`,
+        `${allPrefixes.at(-1) ?? []} ${nameSegment}`.trim(),
       ],
       [] as string[],
     )

--- a/discord-scripts/thread-management/auto-join.ts
+++ b/discord-scripts/thread-management/auto-join.ts
@@ -57,8 +57,28 @@ async function autoJoinThread(
     }
   }
 
+  // All prefixes of the containing channel name, with dashes converted to
+  // spaces, ordered longest to shortest. For example, #mezo-engineering-musd
+  // would produce ["mezo engineering musd", "mezo engineering", "mezo"].
+  const roleMatchPrefixes = containingChannel?.name
+    .toLowerCase()
+    .split("-")
+    .reduce(
+      (allPrefixes, nameSegment) => [
+        ...allPrefixes,
+        `${allPrefixes.at(-1) ?? []} ${nameSegment}`,
+      ],
+      [] as string[],
+    )
+    .reverse()
+
   const matchingRole = server.roles.cache.find(
-    (role) => role.name.toLowerCase() === containingChannel?.name.toLowerCase(),
+    (role) =>
+      roleMatchPrefixes?.some(
+        (channelPrefixRole) =>
+          role.name.toLowerCase() ===
+          channelPrefixRole /* already lowercased above */,
+      ),
   )
 
   if (matchingRole !== undefined) {


### PR DESCRIPTION
In particular, this allows categorizing not just by top-level category in Discord, but also refining by a channel prefix. As an example, a channel #mezo-engineering-musd in the Mezo category would previously only auto-join the roles "Mezo Engineering mUSD" and "Mezo", because one would match the channel and one the category.

The new approach tries all prefixes of the channel name, so that "Mezo Engineering" can also be auto-tagged.

With the current Discord channel name structure, this means most items will be auto-tagged in this phase instead of by category, since project channels always prefix their project name. One key exception is Studio.