### PR TITLE
Add Mezo Figma ID

### DIFF
--- a/discord-scripts/figma-integration.ts
+++ b/discord-scripts/figma-integration.ts
@@ -32,6 +32,7 @@ const teamIdsByName: { [name: string]: string } = {
   keep: "953697796065703632",
   taho: "953697445071473329",
   thesis: "597157463033100784",
+  mezo: "1326283008375098385",
 }
 
 const eventHandlers: {


### PR DESCRIPTION
### Notes
This adds the Mezo project ID to figma commands, in order to get the web hook going.