### PR TITLE
Remove thread reminders on voice channels

### DIFF
--- a/discord-scripts/thread-management/reminder-to-thread.ts
+++ b/discord-scripts/thread-management/reminder-to-thread.ts
@@ -1,4 +1,4 @@
-import { Message } from "discord.js"
+import { Message, ChannelType } from "discord.js"
 import {
   DiscordEventHandlers,
   isInRecreationalCategory,
@@ -18,7 +18,12 @@ async function reminderToThread(message: Message<boolean>) {
   }
 
   // If this message is not in reply to anything, do nothing.
-  if (message.reference === null || message.reference.messageId === undefined) {
+  if (
+    channel.isThread() ||
+    isInRecreationalCategory(channel) ||
+    channel.type === ChannelType.GuildVoice ||
+    channel.type === ChannelType.GuildStageVoice
+  ) {
     return
   }
 


### PR DESCRIPTION
### Notes

- Fixes THESIS-214

This adds a fix to the `reminder-to-threads` in order to exclude voice channels associated to voice or stage channels, since they don't support threads.