### PR TITLE
Change thread decisions time checks

### DIFF
--- a/discord-scripts/thread-management/check-thread-archiving.ts
+++ b/discord-scripts/thread-management/check-thread-archiving.ts
@@ -387,6 +387,18 @@ async function checkThreadStatus(
 
       const currentTime = Date.now()
 
+      // We can then archive the thread if the expiry time has been reached or passed
+      if (autoArchiveTime - currentTime <= 0) {
+        await thread.setArchived(true)
+        await thread.send(
+          "This thread is now archived as the auto-archive duration has been reached.",
+        )
+        robot.logger.info(
+          `Archived thread ${threadId} as the auto-archive time has been reached.`,
+        )
+        return
+      }
+
       // Then check if the thread is within the warning window
       if (
         autoArchiveTime - currentTime <= 24 * HOUR &&

--- a/discord-scripts/thread-management/check-thread-archiving.ts
+++ b/discord-scripts/thread-management/check-thread-archiving.ts
@@ -389,10 +389,26 @@ async function checkThreadStatus(
 
       // We can then archive the thread if the expiry time has been reached or passed
       if (autoArchiveTime - currentTime <= 0) {
+        const warningKey = `thread-warning:${threadId}`
+        const warningMessageId = robot.brain.get(warningKey)
+
+        if (warningMessageId) {
+          try {
+            const warningMessage = await thread.messages.fetch(warningMessageId)
+            // this will edit the original message to indicate the thread has been archived
+            await warningMessage.edit({
+              content:
+                "This thread is now archived as the auto-archive duration has been reached.",
+              components: [],
+            })
+          } catch (error) {
+            robot.logger.error(
+              `Failed to edit the warning message for thread ${threadId}: ${error}`,
+            )
+          }
+        }
+
         await thread.setArchived(true)
-        await thread.send(
-          "This thread is now archived as the auto-archive duration has been reached.",
-        )
         robot.logger.info(
           `Archived thread ${threadId} as the auto-archive time has been reached.`,
         )

--- a/discord-scripts/thread-management/check-thread-archiving.ts
+++ b/discord-scripts/thread-management/check-thread-archiving.ts
@@ -425,9 +425,9 @@ async function checkThreadStatus(
         // Use robot brain to store the warning event data
         robot.brain.set(warningKey, warningMessage.id)
         robot.logger.info(
-          `Sent auto-archive warning for thread ${threadId}. Message ID: ${warningMessage.id}, Auto-archive time: ${new Date(
-            autoArchiveTime,
-          ).toISOString()}`,
+          `Sent auto-archive warning for thread ${threadId}. Message ID: ${
+            warningMessage.id
+          }, Auto-archive time: ${new Date(autoArchiveTime).toISOString()}`,
         )
       } else {
         robot.logger.info(

--- a/discord-scripts/thread-management/check-thread-archiving.ts
+++ b/discord-scripts/thread-management/check-thread-archiving.ts
@@ -263,10 +263,10 @@ async function updateThreadStatusFromMessage(
     return
   }
 
-  const autoArchiveDuration = thread.autoArchiveDuration
+  const { autoArchiveDuration, id: threadId } = thread
 
   robot.logger.info(
-    `New thread being monitored. ID: ${thread.id}, AutoArchiveDuration: ${
+    `New thread being monitored. ID: ${threadId}, AutoArchiveDuration: ${
       autoArchiveDuration ?? "Unknown"
     }`,
   )
@@ -280,7 +280,7 @@ async function updateThreadStatusFromMessage(
     messageTimestamp - (thread.createdTimestamp ?? 0) >
       MAX_HEURISTIC_SYNC_THREAD_DURATION
   ) {
-    robot.logger.info("Marking thread", thread.id, "as async")
+    robot.logger.info("Marking thread", threadId, "as async")
     channelMetadata.sync = false
     updateThreadMetadata(robot.brain, thread, channelMetadata)
   }
@@ -424,7 +424,6 @@ async function checkThreadStatus(
 
         // Use robot brain to store the warning event data
         robot.brain.set(warningKey, warningMessage.id)
-
         robot.logger.info(
           `Sent auto-archive warning for thread ${threadId}. Message ID: ${warningMessage.id}, Auto-archive time: ${new Date(
             autoArchiveTime,


### PR DESCRIPTION
### Notes
This changes the flow of the `checkThreadStatus` so that we take the existing `thread.autoArchiveDuration` and calculate the exact archival time based off the last message. That timestamp is added to the warning message in order to verify the exact archival time that discord will archive automatically.

- Also prevents multiple warning messages to be sent (optional and whether we want this)
- Changes archival behavior to always follow auto archive duration of thread.
- Edits original message when thread is archived (timer hits zero), sets `thread.setArchived: true` 