### PR TITLE
Add linear embed support

### DIFF
--- a/discord-scripts/fix-linear-embed.ts
+++ b/discord-scripts/fix-linear-embed.ts
@@ -1,0 +1,168 @@
+import { Client, EmbedBuilder, TextChannel } from "discord.js"
+import { Log, Robot } from "hubot"
+import { LinearClient } from "@linear/sdk"
+
+const LINEAR_API_TOKEN = process.env.LINEAR_API_TOKEN
+
+async function createLinearEmbed(
+  linearClient: LinearClient,
+  issueId: string,
+  commentId?: string,
+  teamName?: string,
+) {
+  try {
+    const issue = await linearClient.issue(issueId)
+
+    const project = issue.project ? await issue.project : null
+    const state = issue.state ? await issue.state : null
+    const assignee = issue.assignee ? await issue.assignee : null
+    const comments = await issue.comments()
+    const comment = commentId
+      ? comments.nodes.find((c) => c.id.startsWith(commentId))
+      : null
+
+    const embed = new EmbedBuilder()
+
+    if (comment) {
+      // Comment-focused embed
+      embed
+        .setTitle(`Comment on Issue: ${issue.title}`)
+        .setURL(
+          `https://linear.app/${teamName}/issue/${issue.identifier}#comment-${commentId}`,
+        )
+        .setDescription(comment.body || "No comment body available.")
+        .addFields(
+          {
+            name: "Issue",
+            value: `${issue.title} (${state?.name || "No status"})`,
+            inline: false,
+          },
+          {
+            name: "Assignee",
+            value: assignee?.name.toString() || "Unassigned",
+            inline: true,
+          },
+          {
+            name: "Priority",
+            value: issue.priority?.toString() || "None",
+            inline: true,
+          },
+        )
+        .setFooter({ text: `Project: ${project?.name || "No project"}` })
+    } else {
+      // Issue-focused embed
+      embed
+        .setTitle(`Issue: ${issue.title}`)
+        .setURL(`https://linear.app/${teamName}/issue/${issue.identifier}`)
+        .setDescription(issue.description || "No description available.")
+        .addFields(
+          { name: "Status", value: state?.name || "No status", inline: true },
+          {
+            name: "Assignee",
+            value: assignee?.name.toString() || "Unassigned",
+            inline: true,
+          },
+          {
+            name: "Priority",
+            value: issue.priority?.toString() || "None",
+            inline: true,
+          },
+        )
+        .setFooter({ text: `Project: ${project?.name || "No project"}` })
+
+      if (comments.nodes.length > 0) {
+        embed.addFields({
+          name: "Recent Comment",
+          value: comments.nodes[0].body,
+        })
+      }
+    }
+
+    if (issue.updatedAt) {
+      embed.setTimestamp(new Date(issue.updatedAt))
+    }
+
+    return embed
+  } catch (error) {
+    console.error("Error creating Linear embed:", error)
+    return null
+  }
+}
+
+async function processLinearEmbeds(
+  message: string,
+  channel: TextChannel,
+  logger: Log,
+  linearClient: LinearClient,
+) {
+  const issueUrlRegex =
+    /https:\/\/linear\.app\/([a-zA-Z0-9-]+)\/issue\/([a-zA-Z0-9-]+)(?:.*#comment-([a-zA-Z0-9]+))?/g
+
+  const matches = Array.from(message.matchAll(issueUrlRegex))
+
+  if (matches.length === 0) {
+    logger.info("No Linear issue links found in message.")
+    return
+  }
+
+  for (const match of matches) {
+    const teamName = match[1]
+    const issueId = match[2]
+    const commentId = match[3] || undefined
+
+    logger.info(
+      `Processing team: ${teamName}, issue: ${issueId}, comment: ${commentId}`,
+    )
+
+    const embed = await createLinearEmbed(
+      linearClient,
+      issueId,
+      commentId,
+      teamName,
+    )
+    if (embed) {
+      await channel.send({ embeds: [embed] })
+    } else {
+      logger.error(`Failed to create embed for issue ID: ${issueId}`)
+    }
+  }
+}
+
+export default function linearEmbeds(discordClient: Client, robot: Robot) {
+  const linearClient = new LinearClient({ apiKey: LINEAR_API_TOKEN })
+
+  discordClient.on("messageCreate", async (message) => {
+    if (message.author.bot || !(message.channel instanceof TextChannel)) {
+      return
+    }
+
+    robot.logger.info(`Processing message: ${message.content}`)
+    await processLinearEmbeds(
+      message.content,
+      message.channel,
+      robot.logger,
+      linearClient,
+    )
+  })
+
+  discordClient.on("messageUpdate", async (oldMessage, newMessage) => {
+    if (
+      !newMessage.content ||
+      !newMessage.channel ||
+      newMessage.author?.bot ||
+      !(newMessage.channel instanceof TextChannel)
+    ) {
+      return
+    }
+
+    robot.logger.info(
+      `Processing updated message: ${newMessage.content} (was: ${oldMessage?.content})`,
+    )
+    await processLinearEmbeds(
+      newMessage.content,
+      newMessage.channel,
+      robot.logger,
+      linearClient,
+    )
+  })
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Antonio Salazar Cardozo <antonio@thesis.co>",
   "description": "Heimdall can see and hear your every need, and keeps watch for the onset of Ragnarok",
   "dependencies": {
+    "@linear/sdk": "^32.0.0",
     "@types/cookie": "^0.3.1",
     "@types/cookie-parser": "^1.4.3",
     "@types/hubot": "^3.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -473,6 +473,11 @@
   resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.0.tgz#0709e9f4cb252351c609c6e6d8d6779a8d25edff"
   integrity sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==
 
+"@graphql-typed-document-node/core@^3.1.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
+  integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
+
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"
@@ -747,6 +752,15 @@
   dependencies:
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
+
+"@linear/sdk@^32.0.0":
+  version "32.0.0"
+  resolved "https://registry.yarnpkg.com/@linear/sdk/-/sdk-32.0.0.tgz#1882e89321d4572e266cb39463cdd9408b994fe4"
+  integrity sha512-ZENFrq3JIztYSEmHRmt+HYgfEAqCd/vIVJNDNp3vpedz+0M/FZZSnxe1qTOQToIASvxWbaJtc2M6QT/cIcXRyA==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.0"
+    graphql "^15.4.0"
+    isomorphic-unfetch "^3.1.0"
 
 "@mapbox/node-pre-gyp@^1.0.0":
   version "1.0.10"
@@ -3354,6 +3368,11 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
+graphql@^15.4.0:
+  version "15.9.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.9.0.tgz#4e8ca830cfd30b03d44d3edd9cac2b0690304b53"
+  integrity sha512-GCOQdvm7XxV1S4U4CGrsdlEN37245eC8P9zaYCMr6K1BG0IPGy5lUwmJsEOGyl1GD6HXjOtl2keCP9asRBwNvA==
+
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
@@ -3968,6 +3987,14 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+isomorphic-unfetch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz#87341d5f4f7b63843d468438128cb087b7c3e98f"
+  integrity sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==
+  dependencies:
+    node-fetch "^2.6.1"
+    unfetch "^4.2.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -4923,6 +4950,13 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-fetch@^2.6.1:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-fetch@^2.6.7:
   version "2.6.9"
@@ -6466,6 +6500,11 @@ undici@^5.20.0:
   integrity sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==
   dependencies:
     "@fastify/busboy" "^2.0.0"
+
+unfetch@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
+  integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
 
 unhomoglyph@^1.0.6:
   version "1.0.6"


### PR DESCRIPTION
### Notes
This adds a new `fix-linear-embed` script which will take linear links and generate an embed for it. So far this supports two types of embeds:
- Linear Issues: Display information on the issue like description, assignee, priority and link
- Linear Issue Comments: Display comment text, issue information, link to issue

In order to function, this requires an env `LINEAR_API_TOKEN` to be added.