### PR TITLE
Truncate description/comment on Linear embeds

### DIFF
--- a/discord-scripts/fix-linear-embed.ts
+++ b/discord-scripts/fix-linear-embed.ts
@@ -36,7 +36,12 @@ async function createLinearEmbed(
         .setURL(
           `https://linear.app/${teamName}/issue/${issue.identifier}#comment-${commentId}`,
         )
-        .setDescription(comment.body || "No comment body available.")
+        .setDescription(
+          `${(comment.body || "No comment body available.")
+            .split(" ")
+            .slice(0, 50)
+            .join(" ")}...`,
+        )
         .addFields(
           {
             name: "Issue",
@@ -60,7 +65,12 @@ async function createLinearEmbed(
       embed
         .setTitle(`Issue: ${issue.title}`)
         .setURL(`https://linear.app/${teamName}/issue/${issue.identifier}`)
-        .setDescription(issue.description || "No description available.")
+        .setDescription(
+          `${(issue.description || "No description available.")
+            .split(" ")
+            .slice(0, 50)
+            .join(" ")}...`,
+        )
         .addFields(
           { name: "Status", value: state?.name || "No status", inline: true },
           {
@@ -79,7 +89,10 @@ async function createLinearEmbed(
       if (comments.nodes.length > 0) {
         embed.addFields({
           name: "Recent Comment",
-          value: comments.nodes[0].body,
+          value: `${comments.nodes[0].body
+            .split(" ")
+            .slice(0, 25)
+            .join(" ")}...`,
         })
       }
     }

--- a/discord-scripts/fix-linear-embed.ts
+++ b/discord-scripts/fix-linear-embed.ts
@@ -3,6 +3,7 @@ import {
   EmbedBuilder,
   TextChannel,
   ThreadChannel,
+  VoiceChannel,
   Message,
 } from "discord.js"
 import { Log, Robot } from "hubot"
@@ -123,7 +124,7 @@ async function createLinearEmbed(
 
 async function processLinearEmbeds(
   message: string,
-  channel: TextChannel | ThreadChannel,
+  channel: TextChannel | ThreadChannel | VoiceChannel,
   logger: Log,
   linearClient: LinearClient,
 ) {
@@ -180,7 +181,8 @@ export default function linearEmbeds(discordClient: Client, robot: Robot) {
       message.author.bot ||
       !(
         message.channel instanceof TextChannel ||
-        message.channel instanceof ThreadChannel
+        message.channel instanceof ThreadChannel ||
+        message.channel instanceof VoiceChannel
       )
     ) {
       return
@@ -200,7 +202,8 @@ export default function linearEmbeds(discordClient: Client, robot: Robot) {
       !newMessage.content ||
       !(
         newMessage.channel instanceof TextChannel ||
-        newMessage.channel instanceof ThreadChannel
+        newMessage.channel instanceof ThreadChannel ||
+        newMessage.channel instanceof VoiceChannel
       ) ||
       newMessage.author?.bot
     ) {

--- a/discord-scripts/fix-linear-embed.ts
+++ b/discord-scripts/fix-linear-embed.ts
@@ -10,6 +10,24 @@ import { LinearClient } from "@linear/sdk"
 
 const { LINEAR_API_TOKEN } = process.env
 
+function truncateToWords(
+  content: string | undefined,
+  ifBlank: string,
+  maxWords = 50,
+): string {
+  if (content === undefined || content.trim() === "") {
+    return ifBlank
+  }
+
+  const truncatedContent = content.split(" ").slice(0, maxWords).join(" ")
+
+  if (truncatedContent !== content) {
+    return `${truncatedContent}...`
+  }
+
+  return content
+}
+
 async function createLinearEmbed(
   linearClient: LinearClient,
   issueId: string,
@@ -37,10 +55,7 @@ async function createLinearEmbed(
           `https://linear.app/${teamName}/issue/${issue.identifier}#comment-${commentId}`,
         )
         .setDescription(
-          `${(comment.body || "No comment body available.")
-            .split(" ")
-            .slice(0, 50)
-            .join(" ")}...`,
+          truncateToWords(comment.body, "No comment body available.", 50),
         )
         .addFields(
           {
@@ -66,10 +81,7 @@ async function createLinearEmbed(
         .setTitle(`Issue: ${issue.title}`)
         .setURL(`https://linear.app/${teamName}/issue/${issue.identifier}`)
         .setDescription(
-          `${(issue.description || "No description available.")
-            .split(" ")
-            .slice(0, 50)
-            .join(" ")}...`,
+          truncateToWords(issue.description, "No description available.", 50),
         )
         .addFields(
           { name: "Status", value: state?.name || "No status", inline: true },
@@ -89,10 +101,11 @@ async function createLinearEmbed(
       if (comments.nodes.length > 0) {
         embed.addFields({
           name: "Recent Comment",
-          value: `${comments.nodes[0].body
-            .split(" ")
-            .slice(0, 25)
-            .join(" ")}...`,
+          value: truncateToWords(
+            comments.nodes[0].body,
+            "No recent comment.",
+            25,
+          ),
         })
       }
     }


### PR DESCRIPTION
### Notes
Caps each Linear embed description to 50 words and the recent comment section to 25 words. Which will prevent absurdly large embeds from appearing!

Also adds support for `VoiceChannel` 