### PR TITLE
Only run `fixTwitterEmbeds` if conditions are met

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,3 +302,7 @@ can then run hubot with the adapter.
 Where `<adapter>` is the name of your adapter without the `hubot-` prefix.
 
 [hubot-adapters]: https://github.com/github/hubot/blob/master/docs/adapters.md
+
+## Debugging
+
+If you'd like to test certain aspects of Valkyrie with a debugger, use `robot.logger.debug` and in your environment variables the flag `export HUBOT_LOG_LEVEL="debug"` which will enable those messages to appear in terminal output. 

--- a/discord-scripts/fix-twitter-embed.ts
+++ b/discord-scripts/fix-twitter-embed.ts
@@ -69,11 +69,13 @@ async function workingTwitterEmbeds(
 export default function fixTwitterEmbeds(discordClient: Client, robot: Robot) {
   // Process only messages that match the Twitter URL pattern
   discordClient.on("messageCreate", (message) => {
+    robot.logger.debug(
+      `fixTwitterEmbeds: processing new message ${message.content}`,
+    )
     if (message.content?.match(twitterUrlRegExp)) {
       robot.logger.info(
         `fixTwitterEmbeds: processing new message ${message.content}`,
       )
-
       workingTwitterEmbeds(message, robot.logger).catch((err) => {
         robot.logger.error(
           `fixTwitterEmbeds: failed to process new message ${message.content}: ${err}`,
@@ -83,6 +85,9 @@ export default function fixTwitterEmbeds(discordClient: Client, robot: Robot) {
   })
 
   discordClient.on("messageUpdate", (oldMessage, newMessage) => {
+    robot.logger.debug(
+      `fixTwitterEmbeds: processing updated message ${newMessage.content}`,
+    )
     if (
       newMessage.content?.match(twitterUrlRegExp) ||
       oldMessage?.content?.match(twitterUrlRegExp)


### PR DESCRIPTION
### Notes
This resolves an issue where Valkyrie was posting `INFO fixTwitterEmbeds` for every message whether it matches the regex pattern or not. Now we only run the twitter embed if it matches.