### PR TITLE
Add mezo marketing tags

### DIFF
--- a/discord-scripts/thread-management/auto-join.ts
+++ b/discord-scripts/thread-management/auto-join.ts
@@ -31,6 +31,7 @@ interface ChannelRoleMapping {
 const CUSTOM_CHANNEL_ROLE: ChannelRoleMapping[] = [
   { channelName: "biz-dev-investor", roles: ["BD"] },
   { channelName: "press-relations", roles: ["M Group", "Marketing"] },
+  { channelName: "mezo-marketing", roles: ["Mezo Marketing"] },
 ]
 
 async function autoJoinThread(


### PR DESCRIPTION
### Notes
Strange things going on with the `auto-join.ts` helper for the Mezo marketing role, despite working on test instance with different character cases. In the meantime, let's deploy it with this.