### PR TITLE
Re-enable `setAutoArchiveDuration` + `isWeekend` check

### DIFF
--- a/discord-scripts/thread-management/check-thread-archiving.ts
+++ b/discord-scripts/thread-management/check-thread-archiving.ts
@@ -37,7 +37,7 @@ const THREAD_CHECK_CADENCE = 12 * HOUR // 12 * HOUR
 // Use a ThreadAutoArchiveDuration as we'll still lean on Discord to
 // auto-archive after issuing the warning, so we want the value to be
 // one that we can update auto-archiving to.
-// const AUTO_ARCHIVE_WARNING_LEAD_MINUTES: ThreadAutoArchiveDuration = ThreadAutoArchiveDuration.OneDay
+const AUTO_ARCHIVE_WARNING_LEAD_MINUTES: ThreadAutoArchiveDuration = ThreadAutoArchiveDuration.OneDay
 
 /**
  * A helper to request follow-up action on a thread based on the id of the user
@@ -474,7 +474,8 @@ async function checkThreadStatus(
             },
           ],
         })
-
+        // Let's add back setting the thread autoArchive to 24hr after the message is sent
+        await thread.setAutoArchiveDuration(AUTO_ARCHIVE_WARNING_LEAD_MINUTES)
         // Use robot brain to store the warning event data
         robot.brain.set(warningKey, warningMessage.id)
         robot.logger.info(

--- a/discord-scripts/thread-management/check-thread-archiving.ts
+++ b/discord-scripts/thread-management/check-thread-archiving.ts
@@ -40,6 +40,9 @@ const THREAD_CHECK_CADENCE = 12 * HOUR // 12 * HOUR
 const AUTO_ARCHIVE_WARNING_LEAD_MINUTES: ThreadAutoArchiveDuration =
   ThreadAutoArchiveDuration.OneDay
 
+// Let's grab if it's the weekend, 0 = sunday, 6 = saturday
+const isWeekend = (): boolean => [0, 6].includes(new Date().getDay())
+
 /**
  * A helper to request follow-up action on a thread based on the id of the user
  * who will follow up and the initial requester of follow-up action.
@@ -370,6 +373,11 @@ async function checkThreadStatus(
   robot: Robot,
   discordClient: Client,
 ): Promise<void> {
+  if (isWeekend()) {
+    robot.logger.info("Skipping thread status checks on the weekend.")
+    return
+  }
+
   const threadMetadataByThreadId = getAllThreadMetadata(robot.brain)
 
   Object.entries(threadMetadataByThreadId)

--- a/discord-scripts/thread-management/check-thread-archiving.ts
+++ b/discord-scripts/thread-management/check-thread-archiving.ts
@@ -37,7 +37,8 @@ const THREAD_CHECK_CADENCE = 12 * HOUR // 12 * HOUR
 // Use a ThreadAutoArchiveDuration as we'll still lean on Discord to
 // auto-archive after issuing the warning, so we want the value to be
 // one that we can update auto-archiving to.
-const AUTO_ARCHIVE_WARNING_LEAD_MINUTES: ThreadAutoArchiveDuration = ThreadAutoArchiveDuration.OneDay
+const AUTO_ARCHIVE_WARNING_LEAD_MINUTES: ThreadAutoArchiveDuration =
+  ThreadAutoArchiveDuration.OneDay
 
 /**
  * A helper to request follow-up action on a thread based on the id of the user


### PR DESCRIPTION
### Notes
Let's re-enable the `setAutoArchiveDuration` to 24 hours / `OneDay` after the initial warning message is sent. This one also adds a `isWeekend` check so that we don't send thread decision reminders during the weekend days. 