### PR TITLE
Fixes to Linear embeds

### DIFF
--- a/discord-scripts/fix-linear-embed.ts
+++ b/discord-scripts/fix-linear-embed.ts
@@ -13,7 +13,7 @@ const { LINEAR_API_TOKEN } = process.env
 
 // Add channelIDs which should ignore the embed processing entirely
 // #mezo-standup
-const IGNORED_CHANNELS = new Set(["1187783048427741296"])
+// const IGNORED_CHANNELS = new Set(["1187783048427741296"])
 
 // track processed message to avoid duplicates if original message is edited
 const processedMessages = new Map<
@@ -199,10 +199,10 @@ async function processLinearEmbeds(
   logger: Log,
   linearClient: LinearClient,
 ) {
-  if (IGNORED_CHANNELS.has(channel.id)) {
-    logger.debug(`Ignoring embeds in channel: ${channel.id}`)
-    return
-  }
+  // if (IGNORED_CHANNELS.has(channel.id)) {
+  //   logger.debug(`Ignoring embeds in channel: ${channel.id}`)
+  //   return
+  // }
   // Let's include a text call if no embeds are to be used in a message
   if (message.includes("<no_embeds>")) {
     logger.debug(

--- a/discord-scripts/fix-linear-embed.ts
+++ b/discord-scripts/fix-linear-embed.ts
@@ -12,9 +12,8 @@ import { LinearClient } from "@linear/sdk"
 const { LINEAR_API_TOKEN } = process.env
 
 // Add channelIDs which should ignore the embed processing entirely
-const IGNORED_CHANNELS = new Set([
-  "1187783048427741296", //#mezo-standup
-])
+// #mezo-standup
+const IGNORED_CHANNELS = new Set(["1187783048427741296"])
 
 // track processed message to avoid duplicates if original message is edited
 const processedMessages = new Map<
@@ -38,14 +37,14 @@ let issueTagRegex: RegExp | null = null
 
 function initializeIssueTagRegex() {
   issueTagRegex =
-    /(?<!https:\/\/linear\.app\/[a-zA-Z0-9-]+\/issue\/)(?<![\[\<])[A-Z]{3,}-\d+(?![\]\>])\b/gi
+    /(?<!https:\/\/linear\.app\/[a-zA-Z0-9-]+\/issue\/)(?<![<[])[A-Z]{3,}-\d+(?![>\]])\b/gi
 }
 
 const projectRegex =
   /https:\/\/linear\.app\/([a-zA-Z0-9-]+)\/project\/([a-zA-Z0-9-]+)(?:#projectUpdate-([a-zA-Z0-9]+))?/g
 
 const issueUrlRegex =
-  /(?<![\[\<])https:\/\/linear\.app\/([a-zA-Z0-9-]+)\/issue\/([a-zA-Z0-9-]+)(?:.*#comment-([a-zA-Z0-9]+))?(?![\]\>])/g
+  /(?<![<[]])https:\/\/linear\.app\/([a-zA-Z0-9-]+)\/issue\/([a-zA-Z0-9-]+)(?:.*#comment-([a-zA-Z0-9]+))?(?![>\]])/g
 
 function truncateToWords(
   content: string | undefined,
@@ -378,13 +377,13 @@ export default async function linearEmbeds(
     const newIssues = new Set<string>()
 
     if (oldMessage.content) {
-      [
+      ;[
         ...oldMessage.content.matchAll(issueUrlRegex),
         ...oldMessage.content.matchAll(issueTagRegex ?? /$^/),
       ].forEach((match) => oldIssues.add(match[2] ?? match[0]))
     }
 
-    [
+    ;[
       ...newMessage.content.matchAll(issueUrlRegex),
       ...newMessage.content.matchAll(issueTagRegex ?? /$^/),
     ].forEach((match) => newIssues.add(match[2] ?? match[0]))

--- a/discord-scripts/fix-linear-embed.ts
+++ b/discord-scripts/fix-linear-embed.ts
@@ -13,7 +13,7 @@ const { LINEAR_API_TOKEN } = process.env
 
 // Add channelIDs which should ignore the embed processing entirely
 // #mezo-standup
-// const IGNORED_CHANNELS = new Set(["1187783048427741296"])
+const IGNORED_CHANNELS = new Set(["1187783048427741296"])
 
 // track processed message to avoid duplicates if original message is edited
 const processedMessages = new Map<
@@ -199,10 +199,10 @@ async function processLinearEmbeds(
   logger: Log,
   linearClient: LinearClient,
 ) {
-  // if (IGNORED_CHANNELS.has(channel.id)) {
-  //   logger.debug(`Ignoring embeds in channel: ${channel.id}`)
-  //   return
-  // }
+  if (IGNORED_CHANNELS.has(channel.id)) {
+    logger.debug(`Ignoring embeds in channel: ${channel.id}`)
+    return
+  }
   // Let's include a text call if no embeds are to be used in a message
   if (message.includes("<no_embeds>")) {
     logger.debug(

--- a/discord-scripts/fix-linear-embed.ts
+++ b/discord-scripts/fix-linear-embed.ts
@@ -11,6 +11,11 @@ import { LinearClient } from "@linear/sdk"
 
 const { LINEAR_API_TOKEN } = process.env
 
+// Add channelIDs which should ignore the embed processing entirely
+const IGNORED_CHANNELS = new Set([
+  "1187783048427741296", //#mezo-standup
+])
+
 // track processed message to avoid duplicates if original message is edited
 const processedMessages = new Map<
   string,
@@ -27,20 +32,20 @@ const processedMessages = new Map<
 >()
 
 // let us also track sent embeds to delete them if the original message is deleted or edited WIP
-const sentEmbeds = new Map<string, Message>()
+const sentEmbeds = new Map<string, Map<string, Message>>()
 
 let issueTagRegex: RegExp | null = null
 
 function initializeIssueTagRegex() {
   issueTagRegex =
-    /(?<!https:\/\/linear\.app\/[a-zA-Z0-9-]+\/issue\/)[A-Z]{3,}-\d+\b/gi
+    /(?<!https:\/\/linear\.app\/[a-zA-Z0-9-]+\/issue\/)(?<![\[\<])[A-Z]{3,}-\d+(?![\]\>])\b/gi
 }
 
 const projectRegex =
   /https:\/\/linear\.app\/([a-zA-Z0-9-]+)\/project\/([a-zA-Z0-9-]+)(?:#projectUpdate-([a-zA-Z0-9]+))?/g
 
 const issueUrlRegex =
-  /https:\/\/linear\.app\/([a-zA-Z0-9-]+)\/issue\/([a-zA-Z0-9-]+)(?:.*#comment-([a-zA-Z0-9]+))?/g
+  /(?<![\[\<])https:\/\/linear\.app\/([a-zA-Z0-9-]+)\/issue\/([a-zA-Z0-9-]+)(?:.*#comment-([a-zA-Z0-9]+))?(?![\]\>])/g
 
 function truncateToWords(
   content: string | undefined,
@@ -195,6 +200,18 @@ async function processLinearEmbeds(
   logger: Log,
   linearClient: LinearClient,
 ) {
+  if (IGNORED_CHANNELS.has(channel.id)) {
+    logger.debug(`Ignoring embeds in channel: ${channel.id}`)
+    return
+  }
+  // Let's include a text call if no embeds are to be used in a message
+  if (message.includes("<no_embeds>")) {
+    logger.debug(
+      `Skipping embeds for message: ${messageId} (contains <no_embeds>)`,
+    )
+    return
+  }
+
   if (!issueTagRegex) {
     logger.error("IssueTagRegex is not initialized.")
     return
@@ -286,19 +303,31 @@ async function processLinearEmbeds(
         result.embed !== null,
     )
     .forEach(({ embed, issueId }) => {
-      if (embed) {
+      if (!sentEmbeds.has(messageId)) {
+        sentEmbeds.set(messageId, new Map())
+      }
+      const messageEmbeds = sentEmbeds.get(messageId)!
+
+      if (messageEmbeds.has(issueId)) {
+        messageEmbeds
+          .get(issueId)!
+          .edit({ embeds: [embed] })
+          .catch((error) =>
+            logger.error(
+              `Failed to edit embed for issue ID: ${issueId}: ${error}`,
+            ),
+          )
+      } else {
         channel
           .send({ embeds: [embed] })
           .then((sentMessage) => {
-            sentEmbeds.set(messageId, sentMessage)
+            messageEmbeds.set(issueId, sentMessage)
           })
           .catch((error) =>
             logger.error(
               `Failed to send embed for issue ID: ${issueId}: ${error}`,
             ),
           )
-      } else {
-        logger.error(`Failed to create embed for issue ID: ${issueId}`)
       }
     })
 }
@@ -337,71 +366,45 @@ export default async function linearEmbeds(
       !newMessage.content ||
       !(
         newMessage.channel instanceof TextChannel ||
-        newMessage.channel instanceof ThreadChannel ||
-        newMessage.channel instanceof VoiceChannel
+        newMessage.channel instanceof ThreadChannel
       ) ||
       newMessage.author?.bot
     ) {
       return
     }
 
-    const embedMessage = sentEmbeds.get(newMessage.id)
-    const urlMatches = Array.from(newMessage.content.matchAll(issueUrlRegex))
-    const issueMatches = issueTagRegex
-      ? Array.from(newMessage.content.matchAll(issueTagRegex))
-      : []
-    const projectMatches = projectRegex
-      ? Array.from(newMessage.content.matchAll(projectRegex))
-      : []
+    const messageEmbeds = sentEmbeds.get(newMessage.id) ?? new Map()
+    const oldIssues = new Set<string>()
+    const newIssues = new Set<string>()
 
-    if (
-      urlMatches.length === 0 &&
-      issueMatches.length === 0 &&
-      projectMatches.length === 0
-    ) {
-      if (embedMessage) {
-        await embedMessage.delete().catch((error) => {
-          robot.logger.error(
-            `Failed to delete embed for message ID: ${newMessage.id}: ${error}`,
-          )
-        })
-        sentEmbeds.delete(newMessage.id)
-      }
-      return
+    if (oldMessage.content) {
+      [
+        ...oldMessage.content.matchAll(issueUrlRegex),
+        ...oldMessage.content.matchAll(issueTagRegex ?? /$^/),
+      ].forEach((match) => oldIssues.add(match[2] ?? match[0]))
     }
 
-    const match = urlMatches[0] || issueMatches[0] || projectMatches[0]
-    const teamName = match[1] || undefined
-    const issueId = match[2] || match[0]
-    const commentId = urlMatches.length > 0 ? match[3] || undefined : undefined
+    [
+      ...newMessage.content.matchAll(issueUrlRegex),
+      ...newMessage.content.matchAll(issueTagRegex ?? /$^/),
+    ].forEach((match) => newIssues.add(match[2] ?? match[0]))
 
-    if (embedMessage) {
-      // we will then update the existing embed
-      try {
-        const embed = await createLinearEmbed(
-          linearClient,
-          issueId,
-          commentId,
-          teamName,
-        )
-        if (embed) {
-          await embedMessage.edit({ embeds: [embed] })
-          robot.logger.debug(`Updated embed for message ID: ${newMessage.id}`)
-        } else {
-          robot.logger.error(
-            `Failed to create embed for updated message ID: ${newMessage.id}`,
-          )
-        }
-      } catch (error) {
-        robot.logger.error(
-          `Failed to edit embed for message ID: ${newMessage.id}: ${error}`,
-        )
+    oldIssues.forEach((issueId) => {
+      if (!newIssues.has(issueId) && messageEmbeds.has(issueId)) {
+        messageEmbeds.get(issueId)?.delete().catch(console.error)
+        messageEmbeds.delete(issueId)
       }
-    } else {
+    })
+
+    const addedIssues = [...newIssues].filter(
+      (issueId) => !oldIssues.has(issueId) && !messageEmbeds.has(issueId),
+    )
+
+    if (addedIssues.length > 0) {
       await processLinearEmbeds(
         newMessage.content,
         newMessage.id,
-        newMessage.channel as TextChannel | ThreadChannel,
+        newMessage.channel,
         robot.logger,
         linearClient,
       )
@@ -409,13 +412,19 @@ export default async function linearEmbeds(
   })
 
   discordClient.on("messageDelete", async (message) => {
-    const embedMessage = sentEmbeds.get(message.id)
-    if (embedMessage) {
-      await embedMessage.delete().catch((error) => {
-        robot.logger.error(
-          `Failed to delete embed for message ID: ${message.id}: ${error}`,
-        )
-      })
+    const embedMessages = sentEmbeds.get(message.id)
+    if (embedMessages) {
+      await Promise.all(
+        Array.from(embedMessages.values()).map((embedMessage) =>
+          embedMessage.delete().catch((error: unknown) => {
+            if (error instanceof Error) {
+              robot.logger.error(`Failed to delete embed: ${error.message}`)
+            } else {
+              robot.logger.error(`Unknown error: ${error}`)
+            }
+          }),
+        ),
+      )
       sentEmbeds.delete(message.id)
     }
   })

--- a/package.json
+++ b/package.json
@@ -77,5 +77,6 @@
     "lint:js": "eslint .",
     "lint:js:fix": "eslint . --fix",
     "lint": "run-p lint:js lint:types"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
### Notes
This PR resolves a number of issues that were happening with Linear embeds into Discord such as:

- Fix duplicate issues, we now properly delete embeds if the message is updated with messageUpdate
- Add a IGNORED_CHANNEL const so that specific channelIDs can have embeds disabled.
- Add a `<no_embeds>` text event so that if it's present in the message, ignore embeds
- Refactored the regex so that if a ISE-123 is wrapped in `[*]` or `<*>`, we ignore the embeds. In some cases this was causing duplicate issues to be embedded as issue tags were being linked.
- Refactored to get rid of un-necessary duplicate calls