### PR TITLE
Guard against null actor in Linear ProjectUpdate webhook

### DIFF
--- a/discord-scripts/linear-integration.ts
+++ b/discord-scripts/linear-integration.ts
@@ -35,7 +35,7 @@ type LinearWebhookEvent = {
     name: string
     email: string
     avatarUrl: string
-  }
+  } | null
   updatedFrom?: Record<string, unknown>
   url: string
   type: string
@@ -83,8 +83,14 @@ const eventHandlers: Record<
       .setTitle(`Project Update: ${data.project.name}`)
       .setDescription(trimmedDescription)
       .setURL(url)
-      .setAuthor({ name: actor.name, iconURL: actor.avatarUrl })
       .setTimestamp()
+
+    const authorName = actor !== null ? actor.name : "Linear"
+    const authorIconURL =
+      actor !== null
+        ? actor.avatarUrl
+        : "https://avatars.githubusercontent.com/u/46686594?v=4"
+    embed.setAuthor({ name: authorName, iconURL: authorIconURL })
 
     if (!channel.isSendable()) {
       throw new Error("Channel is not sendable")


### PR DESCRIPTION
## Summary

- Marks `actor` as nullable in the `LinearWebhookEvent` type to reflect the actual Linear API behavior
- Falls back to `"Linear"` with Linear's logo when actor is null, so the embed always has an author

## Root cause

Linear webhook payloads can have a `null` actor when an event is triggered by a system/background process, an automated job, or an API key usage that Linear can't attribute to a specific user. The `LinearWebhookEvent` type didn't reflect this, and the `ProjectUpdate` handler unconditionally accessed `actor.name`, causing:

```
TypeError: Cannot read properties of null (reading 'name')
    at Object.ProjectUpdate (discord-scripts/linear-integration.ts:86:32)
```

## Test plan

- [ ] Manually trigger a Linear project update via the UI (actor populated → embed shows user name + avatar)
- [ ] Confirm no crash on webhook events where actor is null (embed shows "Linear" with Linear's logo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)