### PR TITLE
Split incident alert into Critical and High severity buttons

### DIFF
--- a/discord-scripts/incident-report.ts
+++ b/discord-scripts/incident-report.ts
@@ -14,15 +14,21 @@ import { Robot } from "hubot"
 
 // Set to #alarm-trigger channel
 const CHANNEL_ID = "1377183184902688862"
-const { INCIDENT_ROUTING_KEY } = process.env
+const { CRITICAL_INCIDENT_ROUTING_KEY, HIGH_INCIDENT_ROUTING_KEY } = process.env
 
 export default async function incidentReport(
 	discordClient: Client,
 	robot: Robot,
 ) {
-	if (!INCIDENT_ROUTING_KEY) {
+	if (!CRITICAL_INCIDENT_ROUTING_KEY) {
 		robot.logger.error(
-			"INCIDENT_ROUTING_KEY is not set. Skipping incident report setup.",
+			"CRITICAL_INCIDENT_ROUTING_KEY is not set. Skipping incident report setup.",
+		)
+		return
+	}
+	if (!HIGH_INCIDENT_ROUTING_KEY) {
+		robot.logger.error(
+			"HIGH_INCIDENT_ROUTING_KEY is not set. Skipping incident report setup.",
 		)
 		return
 	}
@@ -50,9 +56,13 @@ export default async function incidentReport(
 
 		const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
 			new ButtonBuilder()
-				.setCustomId("incident_yes")
-				.setLabel("🚨 Wake Someone Up!")
+				.setCustomId("incident_critical")
+				.setLabel("🚨 Critical: Security incident or chain halt")
 				.setStyle(ButtonStyle.Danger),
+			new ButtonBuilder()
+				.setCustomId("incident_high")
+				.setLabel("🛎 High: Other high severity incident")
+				.setStyle(ButtonStyle.Primary),
 			new ButtonBuilder()
 				.setCustomId("incident_no")
 				.setLabel("Don't Trigger")
@@ -63,7 +73,6 @@ export default async function incidentReport(
 			await message.reply({
 				content: `**Before triggering an alert, ask yourself:**  
 - Is this incident truly a Critical or High severity issue?  
-- Could this wait until regular business hours without major impact?  
 - Can I resolve this with existing documentation or procedures?`,
 
 				components: [row],
@@ -79,24 +88,50 @@ export default async function incidentReport(
 		async (interaction: Interaction) => {
 			if (!interaction.isButton()) return
 
-			if (interaction.customId === "incident_yes") {
+			if (interaction.customId === "incident_critical") {
 				try {
 					await fetch("https://events.pagerduty.com/v2/enqueue", {
 						method: "POST",
 						headers: { "Content-Type": "application/json" },
 						body: JSON.stringify({
 							payload: {
-								summary: "Mezo Critical alert triggered from Discord",
+								summary: "Mezo Security alert triggered from Discord",
 								severity: "critical",
 								source: "Mezo",
 							},
-							routing_key: INCIDENT_ROUTING_KEY,
+							routing_key: CRITICAL_INCIDENT_ROUTING_KEY,
 							event_action: "trigger",
 						}),
 					})
 
 					await interaction.reply({
-						content: "🚨 Alert has been triggered.",
+						content: "🚨 Critical severity alert has been triggered. Escalating to the Security Response group.",
+					})
+				} catch (error) {
+					robot.logger.error("❌ Failed to trigger alert:", error)
+					await interaction.reply({
+						content: "⚠️ Failed to trigger alert.",
+					})
+				}
+			} else if (interaction.customId === "incident_high") {
+				try {
+					await fetch("https://events.pagerduty.com/v2/enqueue", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({
+							payload: {
+								summary: "Mezo High severity alert triggered from Discord",
+								severity: "critical", // PagerDuty does not support "high"
+								source: "Mezo",
+							},
+							routing_key: HIGH_INCIDENT_ROUTING_KEY,
+							event_action: "trigger",
+						}),
+					})
+
+					await interaction.reply({
+						content:
+							"🛎 High severity alert has been triggered. Note these are handled during business hours.",
 					})
 				} catch (error) {
 					robot.logger.error("❌ Failed to trigger alert:", error)

--- a/infrastructure/docker/Dockerfile
+++ b/infrastructure/docker/Dockerfile
@@ -32,8 +32,9 @@ RUN apk add --no-cache \
 	git && \
 	rm -rf /usr/share/man/
 
-# Install pnpm
-RUN npm install -g pnpm
+# Install pnpm. Pin to v9, the last major that still supports the Node 18
+# runtime this image is built on (pnpm 10 requires Node >=22.13).
+RUN npm install -g pnpm@9
 
 COPY pnpm-lock.yaml package.json ./
 

--- a/infrastructure/kube/thesis-ops/valkyrie-hubot-deployment.yaml
+++ b/infrastructure/kube/thesis-ops/valkyrie-hubot-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: hubot
-#          image: gcr.io/thesis-ops-2748/valkyrie:571907d25da706484e12f7d8c40e03a9d82105a8
+          #          image: gcr.io/thesis-ops-2748/valkyrie:571907d25da706484e12f7d8c40e03a9d82105a8
           env:
             - name: ANTHROPIC_API_KEY
               valueFrom:
@@ -97,11 +97,16 @@ spec:
                 secretKeyRef:
                   name: valkyrie-hubot
                   key: imgflip_api_username
-            - name: INCIDENT_ROUTING_KEY
+            - name: CRITICAL_INCIDENT_ROUTING_KEY
               valueFrom:
                 secretKeyRef:
                   name: valkyrie-hubot
-                  key: incident_routing_key
+                  key: critical_incident_routing_key
+            - name: HIGH_INCIDENT_ROUTING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: valkyrie-hubot
+                  key: high_incident_routing_key
             - name: IMGFLIP_API_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
The single "Wake Someone Up!" button routed every alert through one PagerDuty key, leaving no way to distinguish a security incident or chain halt from other high-severity issues. Replace it with two buttons that page through separate routing keys, so each severity can have its own escalation policy and on-call rotation.